### PR TITLE
ci: package AgentDoctor as a GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,22 +69,95 @@ jobs:
           path: dist/
 
   action-smoke:
-    name: GitHub Action smoke
+    name: GitHub Action smoke · ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: normal output
+            case: normal
+            output-file: test-results/action-report.json
+            expected: success
+          - name: nested output
+            case: nested
+            output-file: test-results/nested/action-report.json
+            expected: success
+          - name: traversal rejected
+            case: traversal
+            output-file: ../report.json
+            expected: failure
+          - name: escaping parent symlink rejected
+            case: parent-symlink
+            output-file: test-results/escape-parent/report.json
+            expected: failure
+          - name: output symlink rejected
+            case: output-symlink
+            output-file: test-results/output-symlink.json
+            expected: failure
+          - name: directory rejected
+            case: directory
+            output-file: test-results/output-directory
+            expected: failure
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Prepare output-path case
+        env:
+          CASE: ${{ matrix.case }}
+        run: |
+          set -euo pipefail
+          mkdir -p test-results
+          case "$CASE" in
+            parent-symlink)
+              ln -s "$RUNNER_TEMP" test-results/escape-parent
+              ;;
+            output-symlink)
+              ln -s "$RUNNER_TEMP/outside-report.json" test-results/output-symlink.json
+              ;;
+            directory)
+              mkdir -p test-results/output-directory
+              ;;
+          esac
+
       - name: Run AgentDoctor action
         id: agentdoctor
+        continue-on-error: ${{ matrix.expected == 'failure' }}
         uses: ./
         with:
           path: fixtures/clean-configured-project
-          output-file: test-results/action-report.json
+          output-file: ${{ matrix.output-file }}
+
+      - name: Validate expected outcome
+        env:
+          ACTUAL_OUTCOME: ${{ steps.agentdoctor.outcome }}
+          EXPECTED_OUTCOME: ${{ matrix.expected }}
+        run: |
+          if [ "$ACTUAL_OUTCOME" != "$EXPECTED_OUTCOME" ]; then
+            echo "expected $EXPECTED_OUTCOME, got $ACTUAL_OUTCOME" >&2
+            exit 1
+          fi
+
+      - name: Validate containment
+        if: matrix.expected == 'failure'
+        env:
+          CASE: ${{ matrix.case }}
+        run: |
+          set -euo pipefail
+          case "$CASE" in
+            parent-symlink)
+              test ! -e "$RUNNER_TEMP/report.json"
+              ;;
+            output-symlink)
+              test ! -e "$RUNNER_TEMP/outside-report.json"
+              ;;
+          esac
 
       - name: Validate JSON report
+        if: matrix.expected == 'success'
         env:
           REPORT_PATH: ${{ steps.agentdoctor.outputs.report-path }}
         run: |
@@ -101,8 +174,9 @@ jobs:
           NODE
 
       - name: Upload AgentDoctor report
+        if: matrix.expected == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: agentdoctor-report
-          path: test-results/action-report.json
+          name: agentdoctor-report-${{ matrix.case }}
+          path: ${{ matrix.output-file }}
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,42 @@ jobs:
         with:
           name: dist
           path: dist/
+
+  action-smoke:
+    name: GitHub Action smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run AgentDoctor action
+        id: agentdoctor
+        uses: ./
+        with:
+          path: fixtures/clean-configured-project
+          output-file: test-results/action-report.json
+
+      - name: Validate JSON report
+        env:
+          REPORT_PATH: ${{ steps.agentdoctor.outputs.report-path }}
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const report = JSON.parse(fs.readFileSync(process.env.REPORT_PATH, "utf8"));
+          if (report.version !== "0.1.3-beta") {
+            throw new Error(`unexpected AgentDoctor version: ${report.version}`);
+          }
+          if (!Array.isArray(report.findings) || report.scoringAvailable !== false) {
+            throw new Error("action report does not match the current JSON contract");
+          }
+          NODE
+
+      - name: Upload AgentDoctor report
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentdoctor-report
+          path: test-results/action-report.json
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ steps:
 
   - name: Audit coding-agent configuration
     id: agentdoctor
-    uses: pranee54/AgentDoctor@v0
+    uses: pranee54/AgentDoctor@v0.1.3-beta
     with:
       path: .
       output-file: agentdoctor-report.json

--- a/README.md
+++ b/README.md
@@ -246,15 +246,45 @@ This is still software that reads untrusted repository trees. Treat findings as 
 
 ## CI usage
 
-Use JSON for automation:
+### GitHub Action
+
+Run AgentDoctor directly in a workflow:
+
+```yaml
+permissions:
+  contents: read
+
+steps:
+  - uses: actions/checkout@v4
+
+  - name: Audit coding-agent configuration
+    id: agentdoctor
+    uses: pranee54/AgentDoctor@v0
+    with:
+      path: .
+      output-file: agentdoctor-report.json
+
+  - name: Upload AgentDoctor report
+    uses: actions/upload-artifact@v4
+    with:
+      name: agentdoctor-report
+      path: ${{ steps.agentdoctor.outputs.report-path }}
+```
+
+The action installs the published `@praneeth_54/agentdoctor@0.1.3-beta` package, runs it with
+`--ci --json`, and writes the report inside the checked-out workspace. It sets up Node.js 20
+for the CLI. The optional `version` input accepts an exact npm version or the `latest` / `beta`
+dist-tag.
+
+### CLI
+
+Use JSON directly in other CI systems:
 
 ```bash
-npx @praneeth_54/agentdoctor --json
+npx @praneeth_54/agentdoctor --ci --json
 ```
 
 `--ci` runs non-interactively. Until readiness scoring ships, successful scans exit `0` even when findings exist, and `--min-score` is accepted but ignored.
-
-There is no packaged GitHub Action yet (planned — [ROADMAP.md](ROADMAP.md)).
 
 Exit codes: [docs/exit-codes.md](docs/exit-codes.md). Compatibility promises: [docs/compatibility.md](docs/compatibility.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,8 @@ Conservative, reversible fixes with dry-run and confirmation:
 
 ### CI packaging
 
-First-class GitHub Action wrapping the CLI with threshold and severity policies.
+- First-class GitHub Action wrapping the published CLI and emitting a JSON artifact
+- Threshold and severity policies after deterministic readiness scoring ships
 
 ## Medium term
 

--- a/action.yml
+++ b/action.yml
@@ -68,15 +68,60 @@ runs:
           throw new Error("path must resolve to a directory inside GITHUB_WORKSPACE");
         }
 
-        const reportPath = path.resolve(workspace, outputInput);
-        if (reportPath === workspace || !isInsideWorkspace(reportPath)) {
+        const requestedReportPath = path.resolve(workspace, outputInput);
+        if (requestedReportPath === workspace || !isInsideWorkspace(requestedReportPath)) {
           throw new Error("output-file must resolve to a file inside GITHUB_WORKSPACE");
         }
 
-        fs.mkdirSync(path.dirname(reportPath), { recursive: true });
-        const reportParent = fs.realpathSync(path.dirname(reportPath));
-        if (!isInsideWorkspace(reportParent)) {
-          throw new Error("output-file parent must remain inside GITHUB_WORKSPACE");
+        const reportRelativePath = path.relative(workspace, requestedReportPath);
+        const reportParts = reportRelativePath.split(path.sep);
+        const reportName = reportParts.pop();
+        let reportParent = workspace;
+
+        for (const part of reportParts) {
+          const candidate = path.join(reportParent, part);
+          let state;
+
+          try {
+            state = fs.lstatSync(candidate);
+          } catch (error) {
+            if (error.code !== "ENOENT") {
+              throw error;
+            }
+
+            try {
+              fs.mkdirSync(candidate);
+            } catch (mkdirError) {
+              if (mkdirError.code !== "EEXIST") {
+                throw mkdirError;
+              }
+            }
+            state = fs.lstatSync(candidate);
+          }
+
+          if (state.isSymbolicLink() || !state.isDirectory()) {
+            throw new Error("output-file parent must not contain symbolic links or non-directories");
+          }
+
+          reportParent = fs.realpathSync(candidate);
+          if (!isInsideWorkspace(reportParent)) {
+            throw new Error("output-file parent must remain inside GITHUB_WORKSPACE");
+          }
+        }
+
+        const reportPath = path.join(reportParent, reportName);
+        try {
+          const reportState = fs.lstatSync(reportPath);
+          if (reportState.isSymbolicLink()) {
+            throw new Error("output-file must not be a symbolic link");
+          }
+          if (!reportState.isFile()) {
+            throw new Error("output-file must be a regular file");
+          }
+        } catch (error) {
+          if (error.code !== "ENOENT") {
+            throw error;
+          }
         }
 
         fs.appendFileSync(githubOutput, `target-path=${target}\nreport-path=${reportPath}\n`);
@@ -92,6 +137,7 @@ runs:
         set -euo pipefail
         node <<'NODE'
         const fs = require("node:fs");
+        const path = require("node:path");
         const { spawnSync } = require("node:child_process");
 
         const version = process.env.AGENTDOCTOR_VERSION;
@@ -136,5 +182,40 @@ runs:
         }
 
         JSON.parse(result.stdout);
-        fs.writeFileSync(reportPath, result.stdout, "utf8");
+        const reportParent = path.dirname(reportPath);
+        const temporaryReportPath = path.join(
+          reportParent,
+          `.agentdoctor-report-${process.pid}-${Date.now()}.tmp`,
+        );
+        let temporaryReportCreated = false;
+
+        try {
+          fs.writeFileSync(temporaryReportPath, result.stdout, {
+            encoding: "utf8",
+            flag: "wx",
+            mode: 0o600,
+          });
+          temporaryReportCreated = true;
+
+          try {
+            const reportState = fs.lstatSync(reportPath);
+            if (reportState.isSymbolicLink()) {
+              throw new Error("output-file became a symbolic link before the report was written");
+            }
+            if (!reportState.isFile()) {
+              throw new Error("output-file became a non-regular file before the report was written");
+            }
+          } catch (error) {
+            if (error.code !== "ENOENT") {
+              throw error;
+            }
+          }
+
+          fs.renameSync(temporaryReportPath, reportPath);
+          temporaryReportCreated = false;
+        } finally {
+          if (temporaryReportCreated) {
+            fs.rmSync(temporaryReportPath, { force: true });
+          }
+        }
         NODE

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,140 @@
+name: AgentDoctor
+description: Audit project-level coding-agent configuration and emit a machine-readable report.
+author: AgentDoctor Contributors
+
+branding:
+  icon: activity
+  color: blue
+
+inputs:
+  path:
+    description: Repository-relative directory to scan.
+    required: false
+    default: .
+  version:
+    description: Published AgentDoctor npm version or supported dist-tag.
+    required: false
+    default: 0.1.3-beta
+  output-file:
+    description: Repository-relative path for the JSON report.
+    required: false
+    default: agentdoctor-report.json
+
+outputs:
+  report-path:
+    description: Absolute path to the generated JSON report.
+    value: ${{ steps.validate.outputs.report-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Validate action inputs
+      id: validate
+      shell: bash
+      env:
+        AGENTDOCTOR_PATH: ${{ inputs.path }}
+        AGENTDOCTOR_OUTPUT_FILE: ${{ inputs.output-file }}
+      run: |
+        set -euo pipefail
+        node <<'NODE'
+        const fs = require("node:fs");
+        const path = require("node:path");
+
+        const workspaceInput = process.env.GITHUB_WORKSPACE;
+        const targetInput = process.env.AGENTDOCTOR_PATH;
+        const outputInput = process.env.AGENTDOCTOR_OUTPUT_FILE;
+        const githubOutput = process.env.GITHUB_OUTPUT;
+
+        if (!workspaceInput || !targetInput || !outputInput || !githubOutput) {
+          throw new Error("GitHub Actions did not provide the required environment");
+        }
+        if ([workspaceInput, targetInput, outputInput].some((value) => /[\r\n]/.test(value))) {
+          throw new Error("Action paths must not contain newlines");
+        }
+
+        const workspace = fs.realpathSync(workspaceInput);
+        const isInsideWorkspace = (candidate) => {
+          const relative = path.relative(workspace, candidate);
+          return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+        };
+
+        const target = fs.realpathSync(path.resolve(workspace, targetInput));
+        if (!isInsideWorkspace(target) || !fs.statSync(target).isDirectory()) {
+          throw new Error("path must resolve to a directory inside GITHUB_WORKSPACE");
+        }
+
+        const reportPath = path.resolve(workspace, outputInput);
+        if (reportPath === workspace || !isInsideWorkspace(reportPath)) {
+          throw new Error("output-file must resolve to a file inside GITHUB_WORKSPACE");
+        }
+
+        fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+        const reportParent = fs.realpathSync(path.dirname(reportPath));
+        if (!isInsideWorkspace(reportParent)) {
+          throw new Error("output-file parent must remain inside GITHUB_WORKSPACE");
+        }
+
+        fs.appendFileSync(githubOutput, `target-path=${target}\nreport-path=${reportPath}\n`);
+        NODE
+
+    - name: Run AgentDoctor
+      shell: bash
+      env:
+        AGENTDOCTOR_TARGET_PATH: ${{ steps.validate.outputs.target-path }}
+        AGENTDOCTOR_REPORT_PATH: ${{ steps.validate.outputs.report-path }}
+        AGENTDOCTOR_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        node <<'NODE'
+        const fs = require("node:fs");
+        const { spawnSync } = require("node:child_process");
+
+        const version = process.env.AGENTDOCTOR_VERSION;
+        const targetPath = process.env.AGENTDOCTOR_TARGET_PATH;
+        const reportPath = process.env.AGENTDOCTOR_REPORT_PATH;
+        const runnerTemp = process.env.RUNNER_TEMP;
+
+        if (!version || !targetPath || !reportPath || !runnerTemp) {
+          throw new Error("GitHub Actions did not provide the validated action environment");
+        }
+        if (!/^(latest|beta|[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$/.test(version)) {
+          throw new Error("version must be an exact npm version or the latest/beta dist-tag");
+        }
+
+        const packageSpec = `@praneeth_54/agentdoctor@${version}`;
+        const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+        const result = spawnSync(
+          npmCommand,
+          [
+            "exec",
+            "--yes",
+            `--package=${packageSpec}`,
+            "--",
+            "agentdoctor",
+            targetPath,
+            "--ci",
+            "--json",
+          ],
+          {
+            cwd: runnerTemp,
+            encoding: "utf8",
+            maxBuffer: 64 * 1024 * 1024,
+            stdio: ["ignore", "pipe", "inherit"],
+          },
+        );
+
+        if (result.error) {
+          throw result.error;
+        }
+        if (result.status !== 0) {
+          process.exit(result.status ?? 3);
+        }
+
+        JSON.parse(result.stdout);
+        fs.writeFileSync(reportPath, result.stdout, "utf8");
+        NODE


### PR DESCRIPTION
Closes #14.

## Summary

- add a thin composite GitHub Action that invokes the published AgentDoctor npm package
- constrain scan and report paths to the checked-out workspace and pin the default package version
- reject parent-path symlinks, final output-file symlinks, directories, and other non-regular outputs
- write reports through a same-directory temporary file and atomic rename rather than following a substituted final-path symlink
- emit a validated JSON report path for later artifact upload
- add an end-to-end six-case `uses: ./` CI smoke matrix and document the current non-scoring exit behavior
- use the existing `v0.1.3-beta` release ref in the copy/paste workflow example

## Type of change

- [x] Bug fix
- [ ] New feature / rule / adapter
- [x] Documentation
- [x] Chore / CI / tooling
- [ ] Breaking change

## Checklist

- [x] `npm run verify` passes from a clean clone of exact head `e055eb7`
- [x] Docs updated for the new user-facing Action
- [x] No rule or adapter behavior changed
- [x] No fixtures or credentials added
- [x] Scanner false-positive behavior is unchanged

## Test plan

- [x] Clean-clone `npm run verify` — 18 test files and 122 tests passed, plus typecheck, lint, formatting, and build
- [x] Executed the exact composite validate/run scripts with GitHub-like environment variables; the published v0.1.3-beta package produced valid JSON reports for normal and nested output paths
- [x] Verified `../report.json`, an escaping parent symlink, an existing final output-file symlink, and a directory output are rejected
- [x] Verified neither symlink case creates an outside-workspace report
- [x] `git diff --check`

## Risk

Low and bounded to CI packaging and output handling. The Action does not change scanner behavior, add readiness scoring, or enforce findings as failures while scoring remains unavailable.
