### PR TITLE
feat: add safe fix for context exclusions

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -16,7 +16,7 @@ export async function runDoctorCommand(): Promise<ExitCode> {
   lines.push(`  ${symbolOk()} Core scan API available`);
   lines.push("");
   lines.push(colors.dim("Environment looks ready."));
-  lines.push(colors.dim("Automatic fixes are not available yet."));
+  lines.push(colors.dim("Run agentdoctor fix --dry-run to preview safe fixes."));
   lines.push("");
   process.stdout.write(lines.join("\n"));
   return EXIT_CODES.SUCCESS;

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -1,23 +1,89 @@
 import { EXIT_CODES, type ExitCode } from "../../types/index.js";
+import { isDirectory } from "../../utils/fs.js";
+import { resolveRepoRoot } from "../../utils/path.js";
+import { applyFixPlan, readCursorignore } from "../../core/fix/apply.js";
+import { buildFixPlan } from "../../core/fix/plan.js";
+import { renderFixPlanTerminal } from "../../core/fix/render.js";
+import { runFix } from "../../core/fix/run.js";
+import { scan } from "../../core/scanner/scan.js";
 import { colors } from "../../utils/colors.js";
 
-/**
- * Safe automatic fixes are not implemented yet.
- */
-export async function runFixCommand(options: {
+export interface FixCommandOptions {
+  targetPath?: string;
   dryRun?: boolean;
   yes?: boolean;
-}): Promise<ExitCode> {
-  const lines: string[] = [];
-  lines.push("");
-  lines.push(colors.bold("AgentDoctor fix"));
-  lines.push("");
-  if (options.dryRun) {
-    lines.push("  Dry-run mode requested.");
+}
+
+/**
+ * Safe Repository Mutation — apply allowlisted agent-config exclusions.
+ */
+export async function runFixCommand(options: FixCommandOptions): Promise<ExitCode> {
+  const target = resolveRepoRoot(options.targetPath ?? process.cwd());
+
+  if (!(await isDirectory(target))) {
+    console.error(`Error: not a directory: ${target}`);
+    return EXIT_CODES.USAGE_ERROR;
   }
-  lines.push("  Fix mode is not implemented yet.");
-  lines.push("  No files were modified.");
-  lines.push("");
-  process.stdout.write(lines.join("\n"));
-  return EXIT_CODES.SUCCESS;
+
+  const dryRun = options.dryRun === true;
+  const yes = options.yes === true;
+
+  try {
+    if (dryRun) {
+      const result = await scan({ cwd: target });
+      const plan = await buildFixPlan(result);
+      const cursorContent = await readCursorignore(plan.root);
+      const applyResult = await applyFixPlan(plan, { dryRun: true });
+      process.stdout.write(
+        renderFixPlanTerminal(plan, {
+          dryRun: true,
+          cursorContent,
+          applyResult,
+        }),
+      );
+      return EXIT_CODES.SUCCESS;
+    }
+
+    const { plan, applyResult, cancelled } = await runFix({
+      cwd: target,
+      dryRun: false,
+      yes,
+    });
+
+    if (cancelled) {
+      process.stdout.write("\n  Cancelled. No files were modified.\n\n");
+      return EXIT_CODES.SUCCESS;
+    }
+
+    const cursorContentAfter = await readCursorignore(plan.root);
+    process.stdout.write(
+      renderFixPlanTerminal(plan, {
+        dryRun: false,
+        cursorContent: cursorContentAfter,
+        applyResult,
+      }),
+    );
+
+    // After apply, show a short re-scan hint / delta for Cursor-fixable rules
+    if (applyResult.writtenFiles.length > 0) {
+      const after = await scan({ cwd: target });
+      const remainingSafeContext = after.findings.filter(
+        (f) =>
+          f.fixability === "safe" &&
+          (f.ruleId === "context/generated-directory" || f.ruleId === "context/large-log-file") &&
+          f.affectedAgents.includes("cursor"),
+      );
+      process.stdout.write(
+        colors.dim(
+          `  Re-scan: ${remainingSafeContext.length} Cursor-related safe context finding(s) remain.\n\n`,
+        ),
+      );
+    }
+
+    return EXIT_CODES.SUCCESS;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    return EXIT_CODES.INTERNAL_ERROR;
+  }
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -81,11 +81,15 @@ export function createProgram(): Command {
 
   program
     .command("fix")
-    .description("Apply safe automatic fixes (not implemented yet)")
+    .description(
+      "Apply safe automatic fixes (Week 1: Cursor .cursorignore for safe context findings)",
+    )
+    .argument("[path]", "Repository path (default: current directory)")
     .option("--dry-run", "Show proposed fixes without writing files", false)
     .option("-y, --yes", "Skip confirmation prompts", false)
-    .action(async (options) => {
+    .action(async (pathArg: string | undefined, options) => {
       const code = await runFixCommand({
+        targetPath: resolveTargetArgument(pathArg),
         dryRun: Boolean(options.dryRun),
         yes: Boolean(options.yes),
       });

--- a/src/core/fix/apply.ts
+++ b/src/core/fix/apply.ts
@@ -1,0 +1,40 @@
+import type { FixApplyResult, FixPlan } from "./types.js";
+import {
+  previewCursorignoreActions,
+  readCursorignore,
+  writeCursorignore,
+} from "./writers/cursorignore.js";
+
+/**
+ * Apply (or dry-run) a fix plan.
+ * Week 1: only `.cursorignore` mutations are supported.
+ */
+export async function applyFixPlan(
+  plan: FixPlan,
+  options: { dryRun: boolean },
+): Promise<FixApplyResult> {
+  const current = await readCursorignore(plan.root);
+  const preview = previewCursorignoreActions(current, plan.actions);
+
+  if (!preview) {
+    return {
+      plan,
+      dryRun: options.dryRun,
+      writtenFiles: [],
+      changedFiles: [],
+    };
+  }
+
+  if (!options.dryRun) {
+    await writeCursorignore(plan.root, preview.after);
+  }
+
+  return {
+    plan,
+    dryRun: options.dryRun,
+    writtenFiles: options.dryRun ? [] : [preview.targetRelativePath],
+    changedFiles: [preview.targetRelativePath],
+  };
+}
+
+export { previewCursorignoreActions, readCursorignore };

--- a/src/core/fix/patterns.ts
+++ b/src/core/fix/patterns.ts
@@ -1,0 +1,31 @@
+import type { Finding } from "../../types/index.js";
+
+const SAFE_CONTEXT_RULES = new Set([
+  "context/generated-directory",
+  "context/large-log-file",
+]);
+
+export function isSafeContextFixRule(ruleId: string): boolean {
+  return SAFE_CONTEXT_RULES.has(ruleId);
+}
+
+/**
+ * Build a gitignore-style pattern that excludes the finding evidence path.
+ * Directories (generated-directory) get a trailing slash.
+ */
+export function patternForFinding(finding: Finding): string | null {
+  const evidencePath = finding.evidence?.path?.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!evidencePath) {
+    return null;
+  }
+
+  if (finding.ruleId === "context/generated-directory") {
+    return evidencePath.endsWith("/") ? evidencePath : `${evidencePath}/`;
+  }
+
+  if (finding.ruleId === "context/large-log-file") {
+    return evidencePath;
+  }
+
+  return null;
+}

--- a/src/core/fix/patterns.ts
+++ b/src/core/fix/patterns.ts
@@ -1,9 +1,6 @@
 import type { Finding } from "../../types/index.js";
 
-const SAFE_CONTEXT_RULES = new Set([
-  "context/generated-directory",
-  "context/large-log-file",
-]);
+const SAFE_CONTEXT_RULES = new Set(["context/generated-directory", "context/large-log-file"]);
 
 export function isSafeContextFixRule(ruleId: string): boolean {
   return SAFE_CONTEXT_RULES.has(ruleId);

--- a/src/core/fix/plan.ts
+++ b/src/core/fix/plan.ts
@@ -65,7 +65,10 @@ export async function buildFixPlan(result: ScanResult): Promise<FixPlan> {
 
     const wantsCursor = finding.affectedAgents.includes("cursor");
     if (wantsCursor && hasCursor) {
-      if (cursorIndex.matchesCursorignore(evidencePath) || cursorIndex.matchesCursorignore(pattern)) {
+      if (
+        cursorIndex.matchesCursorignore(evidencePath) ||
+        cursorIndex.matchesCursorignore(pattern)
+      ) {
         skipped.push({
           findingId: finding.id,
           ruleId: finding.ruleId,
@@ -139,7 +142,10 @@ export function missingPatternsForCursorignore(
     if (existing.includes(pattern)) {
       continue;
     }
-    if (pathMatchesAny(pattern.replace(/\/$/, ""), existing) && existing.some((p) => p === pattern)) {
+    if (
+      pathMatchesAny(pattern.replace(/\/$/, ""), existing) &&
+      existing.some((p) => p === pattern)
+    ) {
       continue;
     }
     // Also skip if an existing pattern already excludes this path

--- a/src/core/fix/plan.ts
+++ b/src/core/fix/plan.ts
@@ -1,0 +1,153 @@
+import path from "node:path";
+
+import type { Finding, ScanResult } from "../../types/index.js";
+import { readTextFile } from "../../utils/fs.js";
+import { createIgnoreIndex, parseIgnoreFile, pathMatchesAny } from "../rules/ignore.js";
+import { isSafeContextFixRule, patternForFinding } from "./patterns.js";
+import type { FixAction, FixPlan, SkippedFix } from "./types.js";
+
+const DEFAULT_MAX_IGNORE_BYTES = 512 * 1024;
+
+function cursorConfigured(result: ScanResult): boolean {
+  return result.agents.some((a) => a.id === "cursor" && (a.detected || a.configured));
+}
+
+async function loadCursorignorePatterns(root: string): Promise<string[]> {
+  const filePath = path.join(root, ".cursorignore");
+  const text = await readTextFile(filePath, DEFAULT_MAX_IGNORE_BYTES);
+  if (text === null) {
+    return [];
+  }
+  return parseIgnoreFile(text);
+}
+
+/**
+ * Build a fix plan from a scan result.
+ * Week 1: Cursor `.cursorignore` appends for safe context findings only.
+ */
+export async function buildFixPlan(result: ScanResult): Promise<FixPlan> {
+  const root = result.repository.root;
+  const skipped: SkippedFix[] = [];
+  const actionsByKey = new Map<string, FixAction>();
+
+  const existingCursorPatterns = await loadCursorignorePatterns(root);
+  const cursorIndex = createIgnoreIndex({
+    gitignorePatterns: [],
+    cursorignorePatterns: existingCursorPatterns,
+  });
+
+  const hasCursor = cursorConfigured(result);
+
+  for (const finding of result.findings) {
+    if (finding.fixability !== "safe") {
+      continue;
+    }
+
+    if (!isSafeContextFixRule(finding.ruleId)) {
+      skipped.push({
+        findingId: finding.id,
+        ruleId: finding.ruleId,
+        reason: "No automated fixer for this safe rule yet",
+      });
+      continue;
+    }
+
+    const pattern = patternForFinding(finding);
+    const evidencePath = finding.evidence?.path?.replace(/\\/g, "/");
+    if (!pattern || !evidencePath) {
+      skipped.push({
+        findingId: finding.id,
+        ruleId: finding.ruleId,
+        reason: "Finding has no usable evidence path",
+      });
+      continue;
+    }
+
+    const wantsCursor = finding.affectedAgents.includes("cursor");
+    if (wantsCursor && hasCursor) {
+      if (cursorIndex.matchesCursorignore(evidencePath) || cursorIndex.matchesCursorignore(pattern)) {
+        skipped.push({
+          findingId: finding.id,
+          ruleId: finding.ruleId,
+          reason: "Already excluded by .cursorignore",
+        });
+      } else {
+        mergeCursorAction(actionsByKey, finding, pattern, evidencePath);
+      }
+    } else if (wantsCursor && !hasCursor) {
+      skipped.push({
+        findingId: finding.id,
+        ruleId: finding.ruleId,
+        reason: "Cursor not detected; skipping .cursorignore fix",
+      });
+    }
+
+    for (const agent of finding.affectedAgents) {
+      if (agent === "cursor") {
+        continue;
+      }
+      skipped.push({
+        findingId: finding.id,
+        ruleId: finding.ruleId,
+        reason: `Fix writer for ${agent} not implemented yet`,
+      });
+    }
+  }
+
+  return {
+    root,
+    actions: [...actionsByKey.values()].sort((a, b) => a.id.localeCompare(b.id)),
+    skipped,
+  };
+}
+
+function mergeCursorAction(
+  actionsByKey: Map<string, FixAction>,
+  finding: Finding,
+  pattern: string,
+  evidencePath: string,
+): void {
+  const key = `cursor:.cursorignore:${pattern}`;
+  const existing = actionsByKey.get(key);
+  if (existing) {
+    if (!existing.findingIds.includes(finding.id)) {
+      existing.findingIds.push(finding.id);
+    }
+    return;
+  }
+
+  actionsByKey.set(key, {
+    id: key,
+    kind: "append-ignore-pattern",
+    agent: "cursor",
+    targetRelativePath: ".cursorignore",
+    pattern,
+    evidencePath,
+    findingIds: [finding.id],
+    description: `Exclude ${evidencePath} from Cursor agent context via .cursorignore`,
+  });
+}
+
+/** Patterns that would be newly appended given current file contents. */
+export function missingPatternsForCursorignore(
+  currentContent: string | null,
+  patterns: string[],
+): string[] {
+  const existing = currentContent === null ? [] : parseIgnoreFile(currentContent);
+  const missing: string[] = [];
+  for (const pattern of patterns) {
+    if (existing.includes(pattern)) {
+      continue;
+    }
+    if (pathMatchesAny(pattern.replace(/\/$/, ""), existing) && existing.some((p) => p === pattern)) {
+      continue;
+    }
+    // Also skip if an existing pattern already excludes this path
+    const evidenceGuess = pattern.endsWith("/") ? pattern.slice(0, -1) : pattern;
+    if (pathMatchesAny(evidenceGuess, existing) || pathMatchesAny(pattern, existing)) {
+      continue;
+    }
+    missing.push(pattern);
+  }
+  return missing;
+}

--- a/src/core/fix/render.ts
+++ b/src/core/fix/render.ts
@@ -1,0 +1,77 @@
+import type { FixApplyResult, FixPlan } from "./types.js";
+import { previewCursorignoreActions } from "./writers/cursorignore.js";
+
+export function renderFixPlanTerminal(
+  plan: FixPlan,
+  options: {
+    dryRun: boolean;
+    cursorContent: string | null;
+    applyResult?: FixApplyResult;
+  },
+): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(options.dryRun ? "AgentDoctor fix (dry-run)" : "AgentDoctor fix");
+  lines.push("");
+
+  if (plan.actions.length === 0) {
+    lines.push("  No applicable fixes.");
+    if (plan.skipped.length > 0) {
+      lines.push("");
+      lines.push(`  Skipped findings: ${plan.skipped.length}`);
+      const reasons = summarizeSkipReasons(plan.skipped.map((s) => s.reason));
+      for (const [reason, count] of reasons) {
+        lines.push(`    - ${reason} (${count})`);
+      }
+    }
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  lines.push(`  Proposed actions: ${plan.actions.length}`);
+  for (const action of plan.actions) {
+    lines.push(`    • [${action.agent}] ${action.description}`);
+    lines.push(`      pattern: ${action.pattern}`);
+    lines.push(`      findings: ${action.findingIds.length}`);
+  }
+
+  const preview = previewCursorignoreActions(options.cursorContent, plan.actions);
+  if (preview) {
+    lines.push("");
+    lines.push("  File changes:");
+    lines.push(`    ${preview.targetRelativePath} (+${preview.patternsToAdd.length} pattern(s))`);
+    lines.push("");
+    for (const previewLine of preview.preview.split("\n")) {
+      lines.push(`  ${previewLine}`);
+    }
+  }
+
+  if (options.applyResult && !options.dryRun) {
+    lines.push("");
+    if (options.applyResult.writtenFiles.length > 0) {
+      lines.push(`  Wrote: ${options.applyResult.writtenFiles.join(", ")}`);
+    } else {
+      lines.push("  No files written.");
+    }
+  } else if (options.dryRun) {
+    lines.push("");
+    lines.push("  No files were modified (dry-run).");
+    lines.push("  Re-run without --dry-run to apply.");
+  }
+
+  if (plan.skipped.length > 0) {
+    lines.push("");
+    lines.push(`  Skipped: ${plan.skipped.length} finding(s) (writers pending or already fixed)`);
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function summarizeSkipReasons(reasons: string[]): Array<[string, number]> {
+  const map = new Map<string, number>();
+  for (const reason of reasons) {
+    map.set(reason, (map.get(reason) ?? 0) + 1);
+  }
+  return [...map.entries()].sort((a, b) => b[1] - a[1]);
+}

--- a/src/core/fix/run.ts
+++ b/src/core/fix/run.ts
@@ -1,0 +1,74 @@
+import readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+import { scan } from "../scanner/scan.js";
+import { applyFixPlan, readCursorignore } from "./apply.js";
+import { buildFixPlan } from "./plan.js";
+import { renderFixPlanTerminal } from "./render.js";
+import type { FixApplyResult, FixPlan } from "./types.js";
+
+export interface RunFixOptions {
+  cwd: string;
+  dryRun: boolean;
+  yes: boolean;
+}
+
+export interface RunFixResult {
+  plan: FixPlan;
+  applyResult: FixApplyResult;
+  cancelled: boolean;
+}
+
+/**
+ * Scan → plan → (confirm) → apply Safe Repository Mutation actions.
+ */
+export async function runFix(options: RunFixOptions): Promise<RunFixResult> {
+  const result = await scan({ cwd: options.cwd });
+  const plan = await buildFixPlan(result);
+  const cursorContent = await readCursorignore(plan.root);
+
+  if (plan.actions.length === 0 || options.dryRun) {
+    const applyResult = await applyFixPlan(plan, { dryRun: true });
+    return { plan, applyResult, cancelled: false };
+  }
+
+  if (!options.yes) {
+    const previewText = renderFixPlanTerminal(plan, {
+      dryRun: true,
+      cursorContent,
+    });
+    process.stdout.write(previewText);
+    const confirmed = await confirm("Apply these changes?");
+    if (!confirmed) {
+      return {
+        plan,
+        applyResult: {
+          plan,
+          dryRun: true,
+          writtenFiles: [],
+          changedFiles: [],
+        },
+        cancelled: true,
+      };
+    }
+  }
+
+  const applyResult = await applyFixPlan(plan, { dryRun: false });
+  return { plan, applyResult, cancelled: false };
+}
+
+async function confirm(question: string): Promise<boolean> {
+  if (!input.isTTY || !output.isTTY) {
+    process.stderr.write(
+      "Error: confirmation required but stdin is not a TTY. Re-run with --yes or --dry-run.\n",
+    );
+    return false;
+  }
+  const rl = readline.createInterface({ input, output });
+  try {
+    const answer = await rl.question(`${question} [y/N] `);
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}

--- a/src/core/fix/types.ts
+++ b/src/core/fix/types.ts
@@ -1,0 +1,41 @@
+import type { AgentId } from "../../types/index.js";
+
+export type FixKind = "append-ignore-pattern";
+
+/** Allowlisted relative paths fix may create or modify. */
+export const FIX_PATH_ALLOWLIST = [".cursorignore"] as const;
+
+export type FixAllowlistedPath = (typeof FIX_PATH_ALLOWLIST)[number];
+
+export interface FixAction {
+  id: string;
+  kind: FixKind;
+  agent: AgentId;
+  targetRelativePath: FixAllowlistedPath;
+  /** Ignore pattern to ensure is present (gitignore-style). */
+  pattern: string;
+  /** Evidence path this pattern is meant to exclude. */
+  evidencePath: string;
+  findingIds: string[];
+  description: string;
+}
+
+export interface SkippedFix {
+  findingId: string;
+  ruleId: string;
+  reason: string;
+}
+
+export interface FixPlan {
+  root: string;
+  actions: FixAction[];
+  skipped: SkippedFix[];
+}
+
+export interface FixApplyResult {
+  plan: FixPlan;
+  dryRun: boolean;
+  writtenFiles: string[];
+  /** Relative paths that would be / were written */
+  changedFiles: string[];
+}

--- a/src/core/fix/writers/cursorignore.ts
+++ b/src/core/fix/writers/cursorignore.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { readTextFile } from "../../../utils/fs.js";
+import { missingPatternsForCursorignore } from "../plan.js";
+import type { FixAction } from "../types.js";
+
+const MAX_BYTES = 512 * 1024;
+const BANNER = "# Added by AgentDoctor";
+
+export interface CursorignoreWritePreview {
+  targetRelativePath: ".cursorignore";
+  patternsToAdd: string[];
+  before: string;
+  after: string;
+  /** Unified-diff-like preview (simplified). */
+  preview: string;
+}
+
+export function buildCursorignoreContent(
+  currentContent: string | null,
+  patternsToAdd: string[],
+): string {
+  if (patternsToAdd.length === 0) {
+    return currentContent ?? "";
+  }
+
+  const base = currentContent ?? "";
+  const trimmed = base.replace(/\s+$/, "");
+  const block = [BANNER, ...patternsToAdd].join("\n");
+  if (trimmed.length === 0) {
+    return `${block}\n`;
+  }
+  return `${trimmed}\n\n${block}\n`;
+}
+
+export function previewCursorignoreActions(
+  currentContent: string | null,
+  actions: FixAction[],
+): CursorignoreWritePreview | null {
+  const cursorActions = actions.filter(
+    (a) => a.agent === "cursor" && a.targetRelativePath === ".cursorignore",
+  );
+  if (cursorActions.length === 0) {
+    return null;
+  }
+
+  const requested = [...new Set(cursorActions.map((a) => a.pattern))];
+  const patternsToAdd = missingPatternsForCursorignore(currentContent, requested);
+  if (patternsToAdd.length === 0) {
+    return null;
+  }
+
+  const before = currentContent ?? "";
+  const after = buildCursorignoreContent(currentContent, patternsToAdd);
+  const preview = formatSimpleDiff(".cursorignore", before, after);
+
+  return {
+    targetRelativePath: ".cursorignore",
+    patternsToAdd,
+    before,
+    after,
+    preview,
+  };
+}
+
+export async function readCursorignore(root: string): Promise<string | null> {
+  return readTextFile(path.join(root, ".cursorignore"), MAX_BYTES);
+}
+
+export async function writeCursorignore(root: string, content: string): Promise<void> {
+  const target = path.join(root, ".cursorignore");
+  const dir = path.dirname(target);
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = path.join(dir, `.cursorignore.agentdoctor.${process.pid}.tmp`);
+  await fs.writeFile(tmp, content, "utf8");
+  await fs.rename(tmp, target);
+}
+
+function formatSimpleDiff(fileLabel: string, before: string, after: string): string {
+  const beforeLines = before.length === 0 ? [] : before.split(/\r?\n/);
+  const afterLines = after.split(/\r?\n/);
+  const lines: string[] = [];
+  lines.push(`--- a/${fileLabel}`);
+  lines.push(`+++ b/${fileLabel}`);
+  // Show only newly added trailing block for clarity
+  const addedStart = beforeLines.length === 0 ? 0 : beforeLines.length;
+  for (let i = addedStart; i < afterLines.length; i++) {
+    const line = afterLines[i];
+    if (line === undefined) {
+      continue;
+    }
+    // Skip pure trailing empty presentation noise except keep structure
+    lines.push(`+${line}`);
+  }
+  if (before.length === 0) {
+    lines.splice(2, 0, "@@ new file @@");
+  } else {
+    lines.splice(2, 0, "@@ append @@");
+  }
+  return lines.join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,7 @@ export { agentRegistry } from "./agents/registry.js";
 export { detectAgents } from "./agents/detect-agents.js";
 export { ruleRegistry, getRuleById } from "./core/rules/registry.js";
 export { runRules } from "./core/rules/run-rules.js";
+export { buildFixPlan } from "./core/fix/plan.js";
+export { applyFixPlan } from "./core/fix/apply.js";
+export { runFix } from "./core/fix/run.js";
+export type { FixPlan, FixAction, FixApplyResult } from "./core/fix/types.js";

--- a/tests/unit/fix/fix-plan.test.ts
+++ b/tests/unit/fix/fix-plan.test.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { scan, buildFixPlan, applyFixPlan } from "../../../src/index.js";
+import { patternForFinding } from "../../../src/core/fix/patterns.js";
+import { previewCursorignoreActions } from "../../../src/core/fix/writers/cursorignore.js";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixturesRoot = path.resolve(here, "../../../fixtures");
+const scratchRoot = path.resolve(here, "../../../test-results");
+
+/**
+ * Minimal Cursor-detected repo without creating a `.cursor/` directory
+ * (some environments block mkdir of `.cursor` outside fixtures).
+ */
+async function makeCursorFixSandbox(options?: {
+  withBuild?: boolean;
+  withLog?: boolean;
+  existingCursorignore?: string;
+}): Promise<string> {
+  await fs.mkdir(scratchRoot, { recursive: true });
+  const root = await fs.mkdtemp(path.join(scratchRoot, "fix-sandbox-"));
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "fix-sandbox", private: true }),
+    "utf8",
+  );
+  await fs.writeFile(path.join(root, "AGENTS.md"), "# Agents\n\nUse AgentDoctor.\n", "utf8");
+
+  if (options?.withBuild !== false) {
+    await fs.mkdir(path.join(root, "build"), { recursive: true });
+    await fs.writeFile(path.join(root, "build", "out.txt"), "generated\n", "utf8");
+  }
+
+  if (options?.withLog) {
+    // Large enough to trip large-log threshold (256 KB default in thresholds)
+    const big = Buffer.alloc(300 * 1024, 0x61);
+    await fs.writeFile(path.join(root, "debug-app.log"), big);
+  }
+
+  if (options?.existingCursorignore !== undefined) {
+    await fs.writeFile(path.join(root, ".cursorignore"), options.existingCursorignore, "utf8");
+  }
+
+  return root;
+}
+
+describe("fix patterns", () => {
+  it("adds trailing slash for generated directories", () => {
+    const pattern = patternForFinding({
+      id: "x",
+      ruleId: "context/generated-directory",
+      category: "context",
+      severity: "info",
+      title: "t",
+      message: "m",
+      whyItMatters: "w",
+      affectedAgents: ["cursor"],
+      fixability: "safe",
+      evidence: { path: "build" },
+    });
+    expect(pattern).toBe("build/");
+  });
+
+  it("keeps file path for large logs", () => {
+    const pattern = patternForFinding({
+      id: "x",
+      ruleId: "context/large-log-file",
+      category: "context",
+      severity: "info",
+      title: "t",
+      message: "m",
+      whyItMatters: "w",
+      affectedAgents: ["cursor"],
+      fixability: "safe",
+      evidence: { path: "debug-app.log" },
+    });
+    expect(pattern).toBe("debug-app.log");
+  });
+});
+
+describe("fix plan + cursorignore writer", () => {
+  it("dry-run proposes .cursorignore patterns for fixture unignored build/", async () => {
+    const result = await scan({
+      cwd: path.join(fixturesRoot, "generated-root-unignored"),
+    });
+    const plan = await buildFixPlan(result);
+
+    expect(plan.actions.some((a) => a.pattern === "build/" && a.agent === "cursor")).toBe(true);
+    expect(plan.actions.every((a) => a.targetRelativePath === ".cursorignore")).toBe(true);
+
+    const preview = previewCursorignoreActions(null, plan.actions);
+    expect(preview).not.toBeNull();
+    expect(preview?.patternsToAdd).toContain("build/");
+    expect(preview?.after).toContain("build/");
+    expect(preview?.after).toContain("Added by AgentDoctor");
+  });
+
+  it("apply writes .cursorignore and clears generated-directory finding", async () => {
+    const root = await makeCursorFixSandbox();
+    try {
+      const before = await scan({ cwd: root });
+      expect(
+        before.findings.some(
+          (f) => f.ruleId === "context/generated-directory" && f.evidence?.path === "build",
+        ),
+      ).toBe(true);
+
+      const plan = await buildFixPlan(before);
+      expect(plan.actions.some((a) => a.pattern === "build/")).toBe(true);
+
+      const applyResult = await applyFixPlan(plan, { dryRun: false });
+      expect(applyResult.writtenFiles).toEqual([".cursorignore"]);
+
+      const written = await fs.readFile(path.join(root, ".cursorignore"), "utf8");
+      expect(written).toContain("build/");
+
+      const after = await scan({ cwd: root });
+      expect(
+        after.findings.some(
+          (f) => f.ruleId === "context/generated-directory" && f.evidence?.path === "build",
+        ),
+      ).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("apply is idempotent when pattern already present", async () => {
+    const root = await makeCursorFixSandbox();
+    try {
+      const firstScan = await scan({ cwd: root });
+      const plan1 = await buildFixPlan(firstScan);
+      await applyFixPlan(plan1, { dryRun: false });
+
+      const secondScan = await scan({ cwd: root });
+      const plan2 = await buildFixPlan(secondScan);
+      expect(plan2.actions.filter((a) => a.agent === "cursor")).toHaveLength(0);
+
+      const apply2 = await applyFixPlan(plan2, { dryRun: false });
+      expect(apply2.writtenFiles).toHaveLength(0);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-run does not write files", async () => {
+    const root = await makeCursorFixSandbox();
+    try {
+      const result = await scan({ cwd: root });
+      const plan = await buildFixPlan(result);
+      await applyFixPlan(plan, { dryRun: true });
+      await expect(fs.access(path.join(root, ".cursorignore"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("proposes exclusion for large log files", async () => {
+    const root = await makeCursorFixSandbox({ withBuild: false, withLog: true });
+    try {
+      const result = await scan({ cwd: root });
+      const plan = await buildFixPlan(result);
+      expect(plan.actions.some((a) => a.pattern === "debug-app.log" && a.agent === "cursor")).toBe(
+        true,
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Week 1 Safe Repository Mutation: `agentdoctor fix` builds an allowlisted plan from safe context findings and can dry-run or apply `.cursorignore` updates for generated directories and large logs
- `.cursorignore` writer only for now; Claude / Codex writers deferred to Week 2
- Adds unit coverage for pattern planning, preview, apply, and idempotency

## Scope
- `src/core/fix/**` + CLI wiring (`fix`, doctor messaging, exports)
- Tests: `tests/unit/fix/fix-plan.test.ts` (7)

## Out of scope
- Claude / Codex writers
- Ops-only changes (SECURITY / templates / workflow perms) — separate follow-up PR

## Test plan
- [x] `npm test -- tests/unit/fix/fix-plan.test.ts` (7/7)
- [x] full `npm test` (151/151) locally on current `main`
- [ ] CI Typecheck · Lint · Test · Build (20/22) green
- [ ] Manual: `agentdoctor fix --dry-run` on a repo with `build/` or a large `.log`

Made with [Cursor](https://cursor.com)