### PR TITLE
chore(deps): bump fixture vite to ^6.4.3

### DIFF
--- a/fixtures/excepta/admin-panel/package.json
+++ b/fixtures/excepta/admin-panel/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/tests/unit/project-detection-013.test.ts
+++ b/tests/unit/project-detection-013.test.ts
@@ -52,7 +52,7 @@ describe("framework detection precision", () => {
   it("detects React from nested package.json dependencies", () => {
     const result = detectFrameworks({
       relativePaths: ["admin-panel/package.json", "admin-panel/src/App.jsx"],
-      packageJsonDependencies: { react: "^18.3.1", "react-dom": "^18.3.1", vite: "^5.4.0" },
+      packageJsonDependencies: { react: "^18.3.1", "react-dom": "^18.3.1", vite: "^6.4.3" },
     });
     expect(result.frameworks).toContain("react");
     expect(result.primaryFramework).toBe("react");


### PR DESCRIPTION
## Summary
- Bump `fixtures/excepta/admin-panel` `vite` from `^5.4.0` to `^6.4.3` to clear open Dependabot alerts
- Align the project-detection unit fixture dep pin with the same floor

## Alerts addressed
- GHSA-fx2h-pf6j-xcff (high) — `server.fs.deny` bypass on Windows alternate paths (patched ≥ 6.4.3)
- GHSA-4w7w-66w2-5vf9 (moderate) — path traversal in optimized deps `.map` handling (patched ≥ 6.4.2)
- GHSA-v6wh-96g9-6wx3 (moderate) — `launch-editor` NTLMv2 hash disclosure via vite (patched ≥ 6.4.3)

## Test plan
- [x] `npm test -- tests/unit/project-detection-013.test.ts`
- [ ] CI green

Made with [Cursor](https://cursor.com)