### PR TITLE
ci: stop cancelling in-flight main workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Keep PR supersession; never cancel in-flight main runs (reruns/outages were wiping them).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,13 +7,14 @@ on:
     branches: [main, master]
   schedule:
     - cron: "17 4 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary
Recent red X’s on `main` were GitHub `Service Unavailable` flakes plus `cancel-in-progress: true` killing overlapping CI/CodeQL reruns.

- Keep cancel-on-PR behavior
- Do **not** cancel in-flight runs on `main`
- Add `workflow_dispatch` so we can recover without empty commits

## Test plan
- [ ] CI + CodeQL green on this PR
- [ ] After merge, `main` CI/CodeQL complete without mutual cancellation

Made with [Cursor](https://cursor.com)