### PR TITLE
chore: npm badge + Action pin for 0.3.0-beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,8 @@ jobs:
         with:
           path: fixtures/clean-configured-project
           output-file: ${{ matrix.output-file }}
-          # Pin to last published npm until 0.3.0-beta is released
-          version: 0.2.0-beta
+          # Published package under latest/beta
+          version: 0.3.0-beta
 
       - name: Validate expected outcome
         env:
@@ -169,7 +169,7 @@ jobs:
           const fs = require("node:fs");
 
           const report = JSON.parse(fs.readFileSync(process.env.REPORT_PATH, "utf8"));
-          if (report.version !== "0.2.0-beta") {
+          if (report.version !== "0.3.0-beta") {
             throw new Error(`unexpected AgentDoctor version: ${report.version}`);
           }
           if (

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AgentDoctor
 
-[![npm](https://img.shields.io/npm/v/@praneeth_54/agentdoctor)](https://www.npmjs.com/package/@praneeth_54/agentdoctor)
+[![npm](https://img.shields.io/npm/v/@praneeth_54/agentdoctor?label=npm)](https://www.npmjs.com/package/@praneeth_54/agentdoctor)
 [![npm downloads](https://img.shields.io/npm/dm/@praneeth_54/agentdoctor)](https://www.npmjs.com/package/@praneeth_54/agentdoctor)
 [![CI](https://img.shields.io/github/actions/workflow/status/pranee54/AgentDoctor/ci.yml?branch=main&label=CI)](https://github.com/pranee54/AgentDoctor/actions)
 [![Node](https://img.shields.io/node/v/@praneeth_54/agentdoctor)](https://nodejs.org)


### PR DESCRIPTION
## Summary
- Bust GitHub/camo cache on the npm version badge so README shows `v0.3.0-beta`
- Point Action smoke at published `0.3.0-beta`