### PR TITLE
feat: complete Scan → Fix → Verify → CI developer loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
     name: GitHub Action smoke · ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: quality
     strategy:
       fail-fast: false
       matrix:
@@ -82,30 +83,112 @@ jobs:
             case: normal
             output-file: test-results/action-report.json
             expected: success
+            path: fixtures/clean-configured-project
+            version: 0.3.0-beta
+            minimum-score: ""
+            fail-on-severity: ""
+            expected-outcome: success
+            summary: "false"
+            annotations: "false"
           - name: nested output
             case: nested
             output-file: test-results/nested/action-report.json
             expected: success
+            path: fixtures/clean-configured-project
+            version: 0.3.0-beta
+            minimum-score: ""
+            fail-on-severity: ""
+            expected-outcome: success
+            summary: "false"
+            annotations: "false"
           - name: traversal rejected
             case: traversal
             output-file: ../report.json
             expected: failure
+            path: fixtures/clean-configured-project
+            version: 0.3.0-beta
+            minimum-score: ""
+            fail-on-severity: ""
+            expected-outcome: ""
+            summary: "false"
+            annotations: "false"
           - name: escaping parent symlink rejected
             case: parent-symlink
             output-file: test-results/escape-parent/report.json
             expected: failure
+            path: fixtures/clean-configured-project
+            version: 0.3.0-beta
+            minimum-score: ""
+            fail-on-severity: ""
+            expected-outcome: ""
+            summary: "false"
+            annotations: "false"
           - name: output symlink rejected
             case: output-symlink
             output-file: test-results/output-symlink.json
             expected: failure
+            path: fixtures/clean-configured-project
+            version: 0.3.0-beta
+            minimum-score: ""
+            fail-on-severity: ""
+            expected-outcome: ""
+            summary: "false"
+            annotations: "false"
           - name: directory rejected
             case: directory
             output-file: test-results/output-directory
             expected: failure
+            path: fixtures/clean-configured-project
+            version: 0.3.0-beta
+            minimum-score: ""
+            fail-on-severity: ""
+            expected-outcome: ""
+            summary: "false"
+            annotations: "false"
+          - name: policy min-score fails
+            case: policy-min-score
+            output-file: test-results/policy-min-score.json
+            expected: failure
+            path: fixtures/insecure-agent-project
+            version: workspace
+            minimum-score: "90"
+            fail-on-severity: ""
+            expected-outcome: policy-failure
+            summary: "true"
+            annotations: "true"
+          - name: policy severity fails
+            case: policy-severity
+            output-file: test-results/policy-severity.json
+            expected: failure
+            path: fixtures/insecure-agent-project
+            version: workspace
+            minimum-score: ""
+            fail-on-severity: critical
+            expected-outcome: policy-failure
+            summary: "true"
+            annotations: "true"
+          - name: policy clean passes
+            case: policy-clean
+            output-file: test-results/policy-clean.json
+            expected: success
+            path: fixtures/clean-configured-project
+            version: workspace
+            minimum-score: "90"
+            fail-on-severity: critical
+            expected-outcome: success
+            summary: "true"
+            annotations: "true"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download build artifact
+        if: matrix.version == 'workspace'
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
 
       - name: Prepare output-path case
         env:
@@ -130,12 +213,15 @@ jobs:
         continue-on-error: ${{ matrix.expected == 'failure' }}
         uses: ./
         with:
-          path: fixtures/clean-configured-project
+          path: ${{ matrix.path }}
           output-file: ${{ matrix.output-file }}
-          # Published package under latest/beta
-          version: 0.3.0-beta
+          version: ${{ matrix.version }}
+          minimum-score: ${{ matrix.minimum-score }}
+          fail-on-severity: ${{ matrix.fail-on-severity }}
+          summary: ${{ matrix.summary }}
+          annotations: ${{ matrix.annotations }}
 
-      - name: Validate expected outcome
+      - name: Validate expected step outcome
         env:
           ACTUAL_OUTCOME: ${{ steps.agentdoctor.outcome }}
           EXPECTED_OUTCOME: ${{ matrix.expected }}
@@ -145,8 +231,19 @@ jobs:
             exit 1
           fi
 
+      - name: Validate action outcome output
+        if: matrix.expected-outcome != ''
+        env:
+          ACTUAL: ${{ steps.agentdoctor.outputs.outcome }}
+          EXPECTED: ${{ matrix.expected-outcome }}
+        run: |
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "expected outcome=$EXPECTED, got $ACTUAL" >&2
+            exit 1
+          fi
+
       - name: Validate containment
-        if: matrix.expected == 'failure'
+        if: matrix.expected == 'failure' && matrix.version != 'workspace'
         env:
           CASE: ${{ matrix.case }}
         run: |
@@ -161,15 +258,16 @@ jobs:
           esac
 
       - name: Validate JSON report
-        if: matrix.expected == 'success'
+        if: matrix.expected == 'success' || startsWith(matrix.case, 'policy-')
         env:
           REPORT_PATH: ${{ steps.agentdoctor.outputs.report-path }}
+          VERSION_MODE: ${{ matrix.version }}
         run: |
           node <<'NODE'
           const fs = require("node:fs");
 
           const report = JSON.parse(fs.readFileSync(process.env.REPORT_PATH, "utf8"));
-          if (report.version !== "0.3.0-beta") {
+          if (process.env.VERSION_MODE !== "workspace" && report.version !== "0.3.0-beta") {
             throw new Error(`unexpected AgentDoctor version: ${report.version}`);
           }
           if (
@@ -183,7 +281,7 @@ jobs:
           NODE
 
       - name: Upload AgentDoctor report
-        if: matrix.expected == 'success'
+        if: matrix.expected == 'success' || startsWith(matrix.case, 'policy-')
         uses: actions/upload-artifact@v4
         with:
           name: agentdoctor-report-${{ matrix.case }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Claude Code safe-context Fix writer: `agentdoctor fix` appends allowlisted
+  `permissions.deny` Read rules to `.claude/settings.json` for
+  `context/generated-directory` and `context/large-log-file` when Claude Code is
+  configured (alongside existing Cursor `.cursorignore` fixes).
+- Codex safe-context Fix writer: `agentdoctor fix` merges allowlisted filesystem
+  `deny` keys into `.codex/config.toml` permission profiles for the same safe
+  context findings when Codex is detected. Skips when `sandbox_mode` is set or
+  `default_permissions` selects a built-in `:…` profile.
+- GitHub Action / CLI CI policy enforcement: `minimum-score` / `--min-score`,
+  `fail-on-severity` / `--fail-on-severity`, `fail-on-rule` / `--fail-on-rule`,
+  `fail-on-new` / `--fail-on-new`, `verify-baseline`, `json-output`, `summary` /
+  `--summary`, and `annotations` / `--annotations`. Action `version: workspace`
+  runs the checked-out `dist/cli` for local CI.
+- Guided Next steps on failed `scan` / `fix` / `verify` terminal output, and on
+  GitHub Step Summary when a policy gate fails — shortest path back to green
+  (reproduce → fix or explain → verify).
+
+### Fixed
+
+- `context/generated-directory` and `context/large-log-file` honor Claude Code Read
+  deny exclusions when computing `affectedAgents`, so Fix → Verify clears Claude
+  context findings after a deny rule is applied.
+- The same rules honor Codex filesystem deny keys in `.codex/config.toml` when
+  computing `affectedAgents`.
+- Action writes the JSON report even when a policy gate fails (exit `1`), so
+  artifacts remain available for triage.
+- `--min-score` / Action `minimum-score` fail when no supported agents are
+  configured (`agentSecurityAnalysis: limited`) instead of passing on a vacuous 100.
+- Terminal readiness prints `n/a` when analysis is limited (no agents).
+- Agentless first scan no longer shows a green “No agent-configuration findings”
+  success line; it tells the user to add Cursor / Claude Code / Codex config and
+  re-run.
+- Invalid `--min-score` values exit `2` (usage) instead of `3` (internal).
+- Codex Fix refuses invalid `.codex/config.toml` during planning (same as Claude
+  invalid JSON) instead of silently skipping Codex and writing Cursor-only fixes.
+- Codex Fix refuses unrecognizable / invalid `.codex/config.toml` content instead of
+  appending permission profiles into garbage TOML.
+- `agentdoctor fix` exits `2` when confirmation is cancelled (non-TTY without `--yes`)
+  or when Fix refuses invalid settings / cannot write due to permissions.
+- `scan --ci` now fails (exit `1`) when any **critical** finding exists. Omit `--ci` for
+  report-only scans. The GitHub Action stays report-only unless policy inputs are set
+  (it no longer passes a bare `--ci`).
+- Discovery keeps oversized log/dump-like paths as size metadata so
+  `context/large-log-file` flags files above the content-read limit (previously silent
+  false negatives for the largest logs).
+
 ## [0.3.0-beta] — 2026-08-07
 
 Minor beta: completes the Scan → Fix → Verify CLI loop and corrects release-facing honesty.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Manually reviewing all of that across Cursor, Claude Code, and Codex is slow and
 | ESLint          | Source code                      |
 | **AgentDoctor** | **AI coding agent environments** |
 
-AgentDoctor analyzes configuration. It does not run agents or call an LLM. `agentdoctor fix` may append safe Cursor ignore patterns; it does not rewrite security settings or credentials.
+AgentDoctor analyzes configuration. It does not run agents or call an LLM. `agentdoctor fix` may append safe context exclusions (Cursor `.cursorignore`, Claude Code Read deny rules, and Codex filesystem deny keys); it does not rewrite secrets, credentials, or security modes such as `bypassPermissions`.
 
 ---
 
@@ -142,7 +142,7 @@ You get deterministic findings with:
 - conservative recommendations
 - readiness score (`scores.overall` in JSON; overall line in the terminal)
 
-Safe Cursor context exclusions can be applied with `agentdoctor fix`. Security and review findings stay manual — Fix explains why and does not invent unsafe edits.
+Safe context exclusions (Cursor / Claude Code / Codex) can be applied with `agentdoctor fix`. Security and review findings stay manual — Fix explains why and does not invent unsafe edits.
 
 ---
 
@@ -173,7 +173,7 @@ agentdoctor
 # 1. Scan (save a baseline for Verify)
 npx @praneeth_54/agentdoctor scan . --json > agentdoctor-report.json
 
-# 2. Fix safe Cursor context exclusions (preview first with --dry-run)
+# 2. Fix safe context exclusions (preview first with --dry-run)
 npx @praneeth_54/agentdoctor fix . --dry-run
 npx @praneeth_54/agentdoctor fix . -y
 
@@ -181,7 +181,16 @@ npx @praneeth_54/agentdoctor fix . -y
 npx @praneeth_54/agentdoctor verify . --baseline agentdoctor-report.json
 ```
 
-`fix` currently writes `.cursorignore` patterns for safe context findings (for example unignored `build/` or large logs). Review/manual security findings are listed as skipped — address those yourself, then re-run `verify`.
+`fix` writes safe context exclusions for Cursor (`.cursorignore`), Claude Code
+(`permissions.deny` Read rules in `.claude/settings.json`), and Codex (filesystem `deny`
+keys under a permissions profile in `.codex/config.toml`) for findings such as unignored
+`build/` or large logs. Review/manual security findings are listed as skipped — address those
+yourself, then re-run `verify`.
+
+> **Published `0.3.0-beta`:** npm and Action `@v0.3.0-beta` still ship Cursor-only Fix
+> (`.cursorignore`). Claude Code / Codex Fix writers, Action policy inputs, and
+> `scan --ci` failing on criticals are in this repository’s Unreleased tree
+> ([CHANGELOG.md](CHANGELOG.md)).
 
 ### Common commands
 
@@ -270,6 +279,8 @@ This is still software that reads untrusted repository trees. Treat findings as 
 
 Run AgentDoctor directly in a workflow:
 
+Published Action `@v0.3.0-beta` is report-only (`path`, `version`, `output-file`):
+
 ```yaml
 permissions:
   contents: read
@@ -291,10 +302,13 @@ steps:
       path: ${{ steps.agentdoctor.outputs.report-path }}
 ```
 
-The action installs the published `@praneeth_54/agentdoctor@0.3.0-beta` package, runs it with
-`--ci --json`, and writes the report inside the checked-out workspace. It sets up Node.js 20
-for the CLI. The optional `version` input accepts an exact npm version or the `latest` / `beta`
-dist-tag.
+Policy inputs (`minimum-score`, `fail-on-severity`, `fail-on-rule`, `fail-on-new`,
+`verify-baseline`, `summary`, `annotations`) exist in this repository’s Unreleased
+`action.yml` and matching CLI. Do not pass them to `@v0.3.0-beta` — that tag ignores them.
+Use this repo’s Action revision (or a later release tag) with a matching CLI (`version` pin
+or `version: workspace`). The action installs `@praneeth_54/agentdoctor` (pin via `version`),
+runs scan (or `verify` when `verify-baseline` is set) with `--json`, and writes the report
+inside the workspace.
 
 ### CLI
 
@@ -302,15 +316,26 @@ Use JSON directly in other CI systems:
 
 ```bash
 # Report-only (exit 0 even when findings exist; scores still in JSON)
-npx @praneeth_54/agentdoctor --ci --json
+npx @praneeth_54/agentdoctor --json
 
-# Fail CI when overall readiness is below 70
-npx @praneeth_54/agentdoctor --ci --json --min-score 70
+# Published 0.3.0-beta: --ci is report-only; use --min-score to fail CI
+npx @praneeth_54/agentdoctor@0.3.0-beta --ci --json --min-score 70
+
+# Unreleased tree CLI: --ci fails on any critical finding
+agentdoctor --ci --json
+
+# Unreleased: fail when overall readiness is below 70 (with --ci also fails on criticals)
+agentdoctor --ci --json --min-score 70
+
+# Unreleased: fail on warning-or-higher (overrides the default critical gate from --ci)
+agentdoctor --ci --json --fail-on-severity warning
 ```
 
-`--ci` runs non-interactively and does **not** apply an implicit score threshold.
-Use `--min-score N` (with or without `--ci`) to fail with exit code `1` when
-`scores.overall < N`.
+In this repository’s Unreleased CLI, `--ci` fails when any **critical** finding exists.
+Override the severity floor with `--fail-on-severity`, and use `--min-score` /
+`--fail-on-rule` for additional gates. Omit `--ci` for report-only JSON (exit `0` even when
+findings exist). Published `0.3.0-beta` treats `--ci` as report-only and does not accept
+`--fail-on-severity` / `--fail-on-rule`.
 
 Exit codes: [docs/exit-codes.md](docs/exit-codes.md). Compatibility promises: [docs/compatibility.md](docs/compatibility.md).
 
@@ -329,15 +354,14 @@ and deferred v2 items): [docs/scoring.md](docs/scoring.md).
 
 Honest limits of the current public beta:
 
-| Limitation                  | Status                                                              |
-| --------------------------- | ------------------------------------------------------------------- |
-| Automatic fixes             | Safe Cursor `.cursorignore` context exclusions only                 |
-| Claude Code / Codex writers | Not implemented — Fix skips with an explicit reason                 |
-| Security findings           | Review/manual — Fix does not rewrite secrets or permission settings |
-| GitHub Action score gates   | Action remains `--ci --json` report-only (no `min-score` input)     |
-| Secret-content scanning     | Filename / config heuristics only                                   |
-| Detection style             | Intentionally conservative; false security findings are avoided     |
-| Agent coverage              | Cursor, Claude Code, Codex project configs                          |
+| Limitation                 | Status                                                              |
+| -------------------------- | ------------------------------------------------------------------- |
+| Automatic fixes            | Safe Cursor / Claude Code / Codex context exclusions (Unreleased; published `0.3.0-beta` is Cursor `.cursorignore` only) |
+| Security findings          | Review/manual — Fix does not rewrite secrets or security modes      |
+| GitHub Action policy gates | Unreleased Action inputs + CLI flags; published `@v0.3.0-beta` is report-only |
+| Secret-content scanning    | Filename / config heuristics only                                   |
+| Detection style            | Intentionally conservative; false security findings are avoided     |
+| Agent coverage             | Cursor, Claude Code, Codex project configs                          |
 
 See [CHANGELOG.md](CHANGELOG.md) and [docs/compatibility.md](docs/compatibility.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,28 +11,45 @@ Deterministic 0–100 scores derived from current findings:
 - Overall
 - Security / Context / Instructions / MCP / Compatibility / Performance
 - Per-agent readiness
-- CLI `--min-score` enforcement (`--ci` alone remains report-only)
+- CLI `--min-score` enforcement
+- Terminal overall readiness line (`N/100`, or `n/a` when analysis is limited)
 
 Documented in [docs/scoring.md](docs/scoring.md).
+
+### Safe context Fix writers
+
+Conservative, reversible fixes with dry-run and confirmation:
+
+- Cursor `.cursorignore` (published `0.3.0-beta`)
+- Claude Code `permissions.deny` Read rules and Codex filesystem `deny` keys (Unreleased in this repository)
 
 ### CI packaging (v0.1.4-beta)
 
 - First-class GitHub Action wrapping the published CLI and emitting a JSON artifact
 
+### CI policy enforcement (Unreleased)
+
+- Shared policy evaluator reused by CLI + Action
+- Action inputs: `minimum-score`, `fail-on-severity`, `fail-on-rule`, `fail-on-new`, `verify-baseline`, `json-output`, `summary`, `annotations`
+- CLI flags: `--fail-on-severity`, `--fail-on-rule`, `--fail-on-new`, `--summary`, `--annotations`
+- `scan --ci` fails on critical findings (report-only = omit `--ci`; published `0.3.0-beta` `--ci` remains report-only)
+- `version: workspace` for local Action CI against `dist/cli`
+
+### Scan → Fix → Verify → CI loop (complete)
+
+First-user workflow is feature-complete and frozen unless real users report friction:
+
+- Local: `doctor` → `scan` → `fix` → `verify`
+- CI: GitHub Action policy failure → Step Summary **Next** → local reproduce / fix / explain → verify → push
+- Terminal Next footers on scan, fix, and verify point to the shortest path back to green
+
+Engineering priority after this milestone: user-reported bugs, corpus-driven precision, performance regressions, and adoption feedback — not more workflow chrome.
+
 ## Near term
-
-### Safe fixes
-
-Conservative, reversible fixes with dry-run and confirmation:
-
-- Ignore entries for sensitive / generated paths
-- Non-destructive boilerplate only when safe
 
 ### Scoring follow-ups (v2+)
 
-- Terminal readiness line
-- GitHub Action `min-score` / severity-gate inputs
-- Other deferred items listed in [docs/scoring.md](docs/scoring.md)
+- Deferred items listed in [docs/scoring.md](docs/scoring.md)
 
 ## Medium term
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: AgentDoctor
-description: Audit project-level coding-agent configuration and emit a machine-readable report.
+description: Audit project-level coding-agent configuration and enforce CI policy gates.
 author: AgentDoctor Contributors
 
 branding:
@@ -12,18 +12,62 @@ inputs:
     required: false
     default: .
   version:
-    description: Published AgentDoctor npm version or supported dist-tag.
+    description: >
+      Published AgentDoctor npm version or dist-tag (latest|beta), or `workspace`
+      to run the checked-out repository's built CLI at dist/cli/index.js.
     required: false
     default: 0.3.0-beta
   output-file:
     description: Repository-relative path for the JSON report.
     required: false
     default: agentdoctor-report.json
+  minimum-score:
+    description: Fail when overall readiness score is below this integer (0-100). Empty skips the gate.
+    required: false
+    default: ""
+  fail-on-severity:
+    description: Fail when any finding has this severity or higher (critical|warning|info). Empty skips the gate.
+    required: false
+    default: ""
+  fail-on-rule:
+    description: Comma-separated rule IDs that fail CI when present (e.g. security/env-file-exposure).
+    required: false
+    default: ""
+  fail-on-new:
+    description: >
+      When verify-baseline is set, fail on new findings vs the baseline.
+      Defaults to true whenever verify-baseline is non-empty unless set to false.
+    required: false
+    default: ""
+  verify-baseline:
+    description: >
+      Repository-relative path to a prior scan JSON baseline. When set, runs
+      `agentdoctor verify` instead of scan.
+    required: false
+    default: ""
+  json-output:
+    description: Write a JSON report to output-file (true/false).
+    required: false
+    default: "true"
+  summary:
+    description: Write a GitHub Actions job step summary (requires CLI with --summary support).
+    required: false
+    default: "false"
+  annotations:
+    description: Emit GitHub Actions annotations for findings (requires CLI with --annotations support).
+    required: false
+    default: "false"
 
 outputs:
   report-path:
-    description: Absolute path to the generated JSON report.
+    description: Absolute path to the generated JSON report (empty when json-output is false).
     value: ${{ steps.validate.outputs.report-path }}
+  outcome:
+    description: success | policy-failure | configuration-error | internal-failure
+    value: ${{ steps.run.outputs.outcome }}
+  overall-score:
+    description: Overall readiness score from the scan/verify result when available.
+    value: ${{ steps.run.outputs.overall-score }}
 
 runs:
   using: composite
@@ -39,6 +83,14 @@ runs:
       env:
         AGENTDOCTOR_PATH: ${{ inputs.path }}
         AGENTDOCTOR_OUTPUT_FILE: ${{ inputs.output-file }}
+        AGENTDOCTOR_JSON_OUTPUT: ${{ inputs.json-output }}
+        AGENTDOCTOR_VERIFY_BASELINE: ${{ inputs.verify-baseline }}
+        AGENTDOCTOR_MINIMUM_SCORE: ${{ inputs.minimum-score }}
+        AGENTDOCTOR_FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
+        AGENTDOCTOR_FAIL_ON_RULE: ${{ inputs.fail-on-rule }}
+        AGENTDOCTOR_FAIL_ON_NEW: ${{ inputs.fail-on-new }}
+        AGENTDOCTOR_SUMMARY: ${{ inputs.summary }}
+        AGENTDOCTOR_ANNOTATIONS: ${{ inputs.annotations }}
       run: |
         set -euo pipefail
         node <<'NODE'
@@ -49,13 +101,32 @@ runs:
         const targetInput = process.env.AGENTDOCTOR_PATH;
         const outputInput = process.env.AGENTDOCTOR_OUTPUT_FILE;
         const githubOutput = process.env.GITHUB_OUTPUT;
+        const jsonOutputRaw = (process.env.AGENTDOCTOR_JSON_OUTPUT || "true").trim().toLowerCase();
+        const verifyBaselineInput = (process.env.AGENTDOCTOR_VERIFY_BASELINE || "").trim();
+        const minimumScoreRaw = (process.env.AGENTDOCTOR_MINIMUM_SCORE || "").trim();
+        const failOnSeverityRaw = (process.env.AGENTDOCTOR_FAIL_ON_SEVERITY || "").trim();
+        const failOnRuleRaw = (process.env.AGENTDOCTOR_FAIL_ON_RULE || "").trim();
+        const failOnNewRaw = (process.env.AGENTDOCTOR_FAIL_ON_NEW || "").trim().toLowerCase();
+        const summaryRaw = (process.env.AGENTDOCTOR_SUMMARY || "false").trim().toLowerCase();
+        const annotationsRaw = (process.env.AGENTDOCTOR_ANNOTATIONS || "false").trim().toLowerCase();
 
         if (!workspaceInput || !targetInput || !outputInput || !githubOutput) {
           throw new Error("GitHub Actions did not provide the required environment");
         }
-        if ([workspaceInput, targetInput, outputInput].some((value) => /[\r\n]/.test(value))) {
+        if ([workspaceInput, targetInput, outputInput, verifyBaselineInput].some((value) => /[\r\n]/.test(value))) {
           throw new Error("Action paths must not contain newlines");
         }
+
+        const parseBool = (value, fallback) => {
+          if (value === "") return fallback;
+          if (value === "true" || value === "1" || value === "yes") return true;
+          if (value === "false" || value === "0" || value === "no") return false;
+          throw new Error(`Invalid boolean action input: ${value}`);
+        };
+
+        const jsonOutput = parseBool(jsonOutputRaw, true);
+        const summary = parseBool(summaryRaw, false);
+        const annotations = parseBool(annotationsRaw, false);
 
         const workspace = fs.realpathSync(workspaceInput);
         const isInsideWorkspace = (candidate) => {
@@ -68,71 +139,128 @@ runs:
           throw new Error("path must resolve to a directory inside GITHUB_WORKSPACE");
         }
 
-        const requestedReportPath = path.resolve(workspace, outputInput);
-        if (requestedReportPath === workspace || !isInsideWorkspace(requestedReportPath)) {
-          throw new Error("output-file must resolve to a file inside GITHUB_WORKSPACE");
-        }
+        let reportPath = "";
+        if (jsonOutput) {
+          const requestedReportPath = path.resolve(workspace, outputInput);
+          if (requestedReportPath === workspace || !isInsideWorkspace(requestedReportPath)) {
+            throw new Error("output-file must resolve to a file inside GITHUB_WORKSPACE");
+          }
 
-        const reportRelativePath = path.relative(workspace, requestedReportPath);
-        const reportParts = reportRelativePath.split(path.sep);
-        const reportName = reportParts.pop();
-        let reportParent = workspace;
+          const reportRelativePath = path.relative(workspace, requestedReportPath);
+          const reportParts = reportRelativePath.split(path.sep);
+          const reportName = reportParts.pop();
+          let reportParent = workspace;
 
-        for (const part of reportParts) {
-          const candidate = path.join(reportParent, part);
-          let state;
+          for (const part of reportParts) {
+            const candidate = path.join(reportParent, part);
+            let state;
 
+            try {
+              state = fs.lstatSync(candidate);
+            } catch (error) {
+              if (error.code !== "ENOENT") {
+                throw error;
+              }
+
+              try {
+                fs.mkdirSync(candidate);
+              } catch (mkdirError) {
+                if (mkdirError.code !== "EEXIST") {
+                  throw mkdirError;
+                }
+              }
+              state = fs.lstatSync(candidate);
+            }
+
+            if (state.isSymbolicLink() || !state.isDirectory()) {
+              throw new Error("output-file parent must not contain symbolic links or non-directories");
+            }
+
+            reportParent = fs.realpathSync(candidate);
+            if (!isInsideWorkspace(reportParent)) {
+              throw new Error("output-file parent must remain inside GITHUB_WORKSPACE");
+            }
+          }
+
+          reportPath = path.join(reportParent, reportName);
           try {
-            state = fs.lstatSync(candidate);
+            const reportState = fs.lstatSync(reportPath);
+            if (reportState.isSymbolicLink()) {
+              throw new Error("output-file must not be a symbolic link");
+            }
+            if (!reportState.isFile()) {
+              throw new Error("output-file must be a regular file");
+            }
           } catch (error) {
             if (error.code !== "ENOENT") {
               throw error;
             }
-
-            try {
-              fs.mkdirSync(candidate);
-            } catch (mkdirError) {
-              if (mkdirError.code !== "EEXIST") {
-                throw mkdirError;
-              }
-            }
-            state = fs.lstatSync(candidate);
-          }
-
-          if (state.isSymbolicLink() || !state.isDirectory()) {
-            throw new Error("output-file parent must not contain symbolic links or non-directories");
-          }
-
-          reportParent = fs.realpathSync(candidate);
-          if (!isInsideWorkspace(reportParent)) {
-            throw new Error("output-file parent must remain inside GITHUB_WORKSPACE");
           }
         }
 
-        const reportPath = path.join(reportParent, reportName);
-        try {
-          const reportState = fs.lstatSync(reportPath);
-          if (reportState.isSymbolicLink()) {
-            throw new Error("output-file must not be a symbolic link");
+        let verifyBaselinePath = "";
+        if (verifyBaselineInput) {
+          const baselineResolved = path.resolve(workspace, verifyBaselineInput);
+          if (!isInsideWorkspace(baselineResolved)) {
+            throw new Error("verify-baseline must resolve inside GITHUB_WORKSPACE");
           }
-          if (!reportState.isFile()) {
-            throw new Error("output-file must be a regular file");
+          if (!fs.existsSync(baselineResolved) || !fs.statSync(baselineResolved).isFile()) {
+            throw new Error("verify-baseline must be an existing file inside GITHUB_WORKSPACE");
           }
-        } catch (error) {
-          if (error.code !== "ENOENT") {
-            throw error;
+          verifyBaselinePath = fs.realpathSync(baselineResolved);
+        }
+
+        if (minimumScoreRaw !== "") {
+          const score = Number(minimumScoreRaw);
+          if (!Number.isInteger(score) || score < 0 || score > 100) {
+            throw new Error("minimum-score must be an integer between 0 and 100");
           }
         }
 
-        fs.appendFileSync(githubOutput, `target-path=${target}\nreport-path=${reportPath}\n`);
+        if (failOnSeverityRaw !== "") {
+          const allowed = new Set(["critical", "warning", "info"]);
+          if (!allowed.has(failOnSeverityRaw.toLowerCase())) {
+            throw new Error("fail-on-severity must be critical, warning, or info");
+          }
+        }
+
+        const failOnNewDefault = verifyBaselinePath !== "";
+        const failOnNew = parseBool(failOnNewRaw, failOnNewDefault);
+        if (failOnNew && !verifyBaselinePath) {
+          throw new Error("fail-on-new requires verify-baseline");
+        }
+
+        const append = (key, value) => {
+          fs.appendFileSync(githubOutput, `${key}=${value}\n`);
+        };
+
+        append("target-path", target);
+        append("report-path", reportPath);
+        append("json-output", jsonOutput ? "true" : "false");
+        append("verify-baseline-path", verifyBaselinePath);
+        append("minimum-score", minimumScoreRaw);
+        append("fail-on-severity", failOnSeverityRaw.toLowerCase());
+        append("fail-on-rule", failOnRuleRaw);
+        append("fail-on-new", failOnNew ? "true" : "false");
+        append("summary", summary ? "true" : "false");
+        append("annotations", annotations ? "true" : "false");
         NODE
 
     - name: Run AgentDoctor
+      id: run
       shell: bash
       env:
         AGENTDOCTOR_TARGET_PATH: ${{ steps.validate.outputs.target-path }}
         AGENTDOCTOR_REPORT_PATH: ${{ steps.validate.outputs.report-path }}
         AGENTDOCTOR_VERSION: ${{ inputs.version }}
+        AGENTDOCTOR_JSON_OUTPUT: ${{ steps.validate.outputs.json-output }}
+        AGENTDOCTOR_VERIFY_BASELINE_PATH: ${{ steps.validate.outputs.verify-baseline-path }}
+        AGENTDOCTOR_MINIMUM_SCORE: ${{ steps.validate.outputs.minimum-score }}
+        AGENTDOCTOR_FAIL_ON_SEVERITY: ${{ steps.validate.outputs.fail-on-severity }}
+        AGENTDOCTOR_FAIL_ON_RULE: ${{ steps.validate.outputs.fail-on-rule }}
+        AGENTDOCTOR_FAIL_ON_NEW: ${{ steps.validate.outputs.fail-on-new }}
+        AGENTDOCTOR_SUMMARY: ${{ steps.validate.outputs.summary }}
+        AGENTDOCTOR_ANNOTATIONS: ${{ steps.validate.outputs.annotations }}
       run: |
         set -euo pipefail
         node <<'NODE'
@@ -142,80 +270,184 @@ runs:
 
         const version = process.env.AGENTDOCTOR_VERSION;
         const targetPath = process.env.AGENTDOCTOR_TARGET_PATH;
-        const reportPath = process.env.AGENTDOCTOR_REPORT_PATH;
+        const reportPath = process.env.AGENTDOCTOR_REPORT_PATH || "";
         const runnerTemp = process.env.RUNNER_TEMP;
+        const workspace = process.env.GITHUB_WORKSPACE;
+        const githubOutput = process.env.GITHUB_OUTPUT;
+        const jsonOutput = process.env.AGENTDOCTOR_JSON_OUTPUT === "true";
+        const verifyBaselinePath = process.env.AGENTDOCTOR_VERIFY_BASELINE_PATH || "";
+        const minimumScore = (process.env.AGENTDOCTOR_MINIMUM_SCORE || "").trim();
+        const failOnSeverity = (process.env.AGENTDOCTOR_FAIL_ON_SEVERITY || "").trim();
+        const failOnRule = (process.env.AGENTDOCTOR_FAIL_ON_RULE || "").trim();
+        const failOnNew = process.env.AGENTDOCTOR_FAIL_ON_NEW === "true";
+        const summary = process.env.AGENTDOCTOR_SUMMARY === "true";
+        const annotations = process.env.AGENTDOCTOR_ANNOTATIONS === "true";
 
-        if (!version || !targetPath || !reportPath || !runnerTemp) {
+        function setOutput(key, value) {
+          fs.appendFileSync(githubOutput, `${key}=${value}\n`);
+        }
+
+        if (!version || !targetPath || !runnerTemp || !workspace || !githubOutput) {
+          setOutput("outcome", "configuration-error");
           throw new Error("GitHub Actions did not provide the validated action environment");
         }
-        if (!/^(latest|beta|[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$/.test(version)) {
-          throw new Error("version must be an exact npm version or the latest/beta dist-tag");
+
+        const isWorkspace = version === "workspace";
+        if (
+          !isWorkspace &&
+          !/^(latest|beta|[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$/.test(version)
+        ) {
+          setOutput("outcome", "configuration-error");
+          throw new Error("version must be an exact npm version, latest/beta, or workspace");
         }
 
-        const packageSpec = `@praneeth_54/agentdoctor@${version}`;
-        const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-        const result = spawnSync(
-          npmCommand,
-          [
+        const args = [];
+        if (verifyBaselinePath) {
+          args.push("verify", targetPath, "--baseline", verifyBaselinePath);
+          if (failOnNew) {
+            args.push("--fail-on-new");
+          }
+        } else {
+          // Report-only by default. Policy inputs (minimum-score / fail-on-severity / …)
+          // enforce gates without implying --ci, so Action stays non-failing until configured.
+          args.push(targetPath);
+        }
+
+        if (jsonOutput) {
+          args.push("--json");
+        }
+        if (minimumScore !== "") {
+          args.push("--min-score", minimumScore);
+        }
+        if (failOnSeverity !== "") {
+          args.push("--fail-on-severity", failOnSeverity);
+        }
+        if (failOnRule !== "") {
+          args.push("--fail-on-rule", failOnRule);
+        }
+        if (summary) {
+          args.push("--summary");
+        }
+        if (annotations) {
+          args.push("--annotations");
+        }
+
+        let command;
+        let commandArgs;
+        if (isWorkspace) {
+          const localCli = path.join(workspace, "dist", "cli", "index.js");
+          if (!fs.existsSync(localCli)) {
+            setOutput("outcome", "configuration-error");
+            throw new Error(
+              "version=workspace requires dist/cli/index.js (run npm run build in this repository first)",
+            );
+          }
+          command = process.execPath;
+          commandArgs = [localCli, ...args];
+        } else {
+          const packageSpec = `@praneeth_54/agentdoctor@${version}`;
+          const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+          command = npmCommand;
+          commandArgs = [
             "exec",
             "--yes",
             `--package=${packageSpec}`,
             "--",
             "agentdoctor",
-            targetPath,
-            "--ci",
-            "--json",
-          ],
-          {
-            cwd: runnerTemp,
-            encoding: "utf8",
-            maxBuffer: 64 * 1024 * 1024,
-            stdio: ["ignore", "pipe", "inherit"],
-          },
-        );
+            ...args,
+          ];
+        }
+
+        const result = spawnSync(command, commandArgs, {
+          cwd: isWorkspace ? workspace : runnerTemp,
+          encoding: "utf8",
+          maxBuffer: 64 * 1024 * 1024,
+          stdio: ["ignore", "pipe", "inherit"],
+          env: process.env,
+        });
 
         if (result.error) {
+          setOutput("outcome", "internal-failure");
           throw result.error;
         }
-        if (result.status !== 0) {
-          process.exit(result.status ?? 3);
-        }
 
-        JSON.parse(result.stdout);
-        const reportParent = path.dirname(reportPath);
-        const temporaryReportPath = path.join(
-          reportParent,
-          `.agentdoctor-report-${process.pid}-${Date.now()}.tmp`,
-        );
-        let temporaryReportCreated = false;
+        const status = result.status ?? 3;
+        let overallScore = "";
 
-        try {
-          fs.writeFileSync(temporaryReportPath, result.stdout, {
-            encoding: "utf8",
-            flag: "wx",
-            mode: 0o600,
-          });
-          temporaryReportCreated = true;
-
+        if (jsonOutput && typeof result.stdout === "string" && result.stdout.trim().length > 0) {
+          let parsed;
           try {
-            const reportState = fs.lstatSync(reportPath);
-            if (reportState.isSymbolicLink()) {
-              throw new Error("output-file became a symbolic link before the report was written");
-            }
-            if (!reportState.isFile()) {
-              throw new Error("output-file became a non-regular file before the report was written");
-            }
+            parsed = JSON.parse(result.stdout);
           } catch (error) {
-            if (error.code !== "ENOENT") {
-              throw error;
-            }
+            setOutput("outcome", "internal-failure");
+            throw new Error(`AgentDoctor did not emit valid JSON: ${error.message}`);
           }
 
-          fs.renameSync(temporaryReportPath, reportPath);
-          temporaryReportCreated = false;
-        } finally {
-          if (temporaryReportCreated) {
-            fs.rmSync(temporaryReportPath, { force: true });
+          if (parsed && parsed.scores && typeof parsed.scores.overall === "number") {
+            overallScore = String(parsed.scores.overall);
+          } else if (
+            parsed &&
+            parsed.after &&
+            parsed.after.scores &&
+            typeof parsed.after.scores.overall === "number"
+          ) {
+            overallScore = String(parsed.after.scores.overall);
+          }
+
+          if (reportPath) {
+            const reportParent = path.dirname(reportPath);
+            const temporaryReportPath = path.join(
+              reportParent,
+              `.agentdoctor-report-${process.pid}-${Date.now()}.tmp`,
+            );
+            let temporaryReportCreated = false;
+
+            try {
+              fs.writeFileSync(temporaryReportPath, result.stdout, {
+                encoding: "utf8",
+                flag: "wx",
+                mode: 0o600,
+              });
+              temporaryReportCreated = true;
+
+              try {
+                const reportState = fs.lstatSync(reportPath);
+                if (reportState.isSymbolicLink()) {
+                  throw new Error("output-file became a symbolic link before the report was written");
+                }
+                if (!reportState.isFile()) {
+                  throw new Error("output-file became a non-regular file before the report was written");
+                }
+              } catch (error) {
+                if (error.code !== "ENOENT") {
+                  throw error;
+                }
+              }
+
+              fs.renameSync(temporaryReportPath, reportPath);
+              temporaryReportCreated = false;
+            } finally {
+              if (temporaryReportCreated) {
+                fs.rmSync(temporaryReportPath, { force: true });
+              }
+            }
           }
         }
+
+        setOutput("overall-score", overallScore);
+
+        if (status === 0) {
+          setOutput("outcome", "success");
+          process.exit(0);
+        }
+        if (status === 1) {
+          setOutput("outcome", "policy-failure");
+          process.exit(1);
+        }
+        if (status === 2) {
+          setOutput("outcome", "configuration-error");
+          process.exit(2);
+        }
+        setOutput("outcome", "internal-failure");
+        process.exit(status);
         NODE

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ Reporters
       terminal (human) · JSON (CI / machines)
 ```
 
-Scoring and automatic fixes are intentionally separate later stages.
+Scoring and automatic fixes are separate pipeline stages after findings.
 
 ## Package layout
 
@@ -36,10 +36,12 @@ src/
     scanner/     public scan() orchestration
     rules/       rule types, runner, security/context/instructions/mcp
     mcp/         project MCP config parsing (no execution)
-    scoring/     reserved for readiness scoring
+    scoring/     readiness scoring
+    fix/         safe fix plan + apply (Cursor / Claude / Codex writers)
+    policy/      CI policy evaluation (CLI + Action)
   detectors/     repository fingerprinting
   discovery/     filesystem walk
-  reporters/     terminal + JSON
+  reporters/     terminal + JSON (+ GitHub summary/annotations)
   security/      redaction / sanitization helpers
   types/         shared contracts
   index.ts       programmatic API
@@ -50,7 +52,7 @@ src/
 1. **Zero config** for first use
 2. **Useful offline** — no API key for core features
 3. **Local-first / privacy-first** — no default upload
-4. **Never modify files** unless explicitly requested (future fix mode)
+4. **Never modify files** unless the user runs `fix` (or calls `applyFixPlan`)
 5. **Every finding explains why** and, when possible, what to do
 6. **Adapters over hardcoding** — new agents register without rewriting the scanner
 7. **Minimal dependencies**
@@ -59,7 +61,7 @@ src/
 ## Public API
 
 ```ts
-import { scan } from "@praneeth_54/agentdoctor";
+import { scan, verify, buildFixPlan, applyFixPlan } from "@praneeth_54/agentdoctor";
 
 const result = await scan({ cwd: process.cwd() });
 ```
@@ -71,11 +73,15 @@ Scanning must not depend on terminal formatting.
 ```text
 agentdoctor [path]
 agentdoctor scan [path]
+agentdoctor fix [path]
+agentdoctor verify [path]
 agentdoctor explain <rule>
 agentdoctor doctor
-agentdoctor fix          # reserved
 agentdoctor --json
 agentdoctor --ci
+agentdoctor --min-score <n>
+agentdoctor --fail-on-severity <level>
+agentdoctor --fail-on-rule <id>
 agentdoctor --verbose
 agentdoctor --version
 agentdoctor --help

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,45 +4,47 @@ This document describes what consumers can rely on during the public beta.
 
 ## Stable in v0.3.x
 
-| Surface          | Promise                                                                                                                                  |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| npm package name | `@praneeth_54/agentdoctor`                                                                                                               |
-| CLI binary name  | `agentdoctor`                                                                                                                            |
-| Default command  | Scan current directory / path argument                                                                                                   |
-| Flags            | `--json`, `--ci`, `--verbose`, `--min-score`, `--version`, `--help`                                                                      |
-| Commands         | `scan`, `fix`, `verify`, `explain <rule>`, `doctor`                                                                                      |
-| Exit codes       | `0` success, `1` threshold / CI regression, `2` usage, `3` internal (see [exit-codes.md](exit-codes.md))                                 |
-| Rule IDs         | `category/name` strings documented in [rules.md](rules.md)                                                                               |
-| Programmatic API | `scan()`, `verify()`, `buildFixPlan()`, `applyFixPlan()`, and `PACKAGE_VERSION` from package root export                                 |
-| JSON top-level   | `version`, `repository`, `agents`, `findings`, `summary`, `scores`, `scoringAvailable`, `agentSecurityAnalysis`, `timing`, `diagnostics` |
+| Surface          | Promise                                                                                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| npm package name | `@praneeth_54/agentdoctor`                                                                                                                                          |
+| CLI binary name  | `agentdoctor`                                                                                                                                                       |
+| Default command  | Scan current directory / path argument                                                                                                                              |
+| Flags (published `0.3.0-beta`) | `--json`, `--ci` (report-only on scan), `--verbose`, `--min-score`, `--version`, `--help`                                                               |
+| Flags (Unreleased tree) | Above, plus `--fail-on-severity`, `--fail-on-rule`, `--fail-on-new` (verify), `--summary`, `--annotations`; `scan --ci` fails on criticals                    |
+| Commands         | `scan`, `fix`, `verify`, `explain <rule>`, `doctor`                                                                                                                 |
+| Exit codes       | `0` success, `1` policy / threshold / CI regression, `2` usage, `3` internal (see [exit-codes.md](exit-codes.md))                                                   |
+| Rule IDs         | `category/name` strings documented in [rules.md](rules.md)                                                                                                          |
+| Programmatic API | `scan()`, `verify()`, `buildFixPlan()`, `applyFixPlan()`, and `PACKAGE_VERSION` from package root export                                                            |
+| JSON top-level   | `version`, `repository`, `agents`, `findings`, `summary`, `scores`, `scoringAvailable`, `agentSecurityAnalysis`, `timing`, `diagnostics`                            |
 
 ## Scoring (v1 shipped)
 
-| Surface             | Notes                                                                                             |
-| ------------------- | ------------------------------------------------------------------------------------------------- |
-| `scoringAvailable`  | `true`                                                                                            |
-| `scores`            | Populated `{ overall, categories, agents }` integers in `[0, 100]` (see [scoring.md](scoring.md)) |
-| Terminal summary    | Prints overall readiness (`N/100`); category/agent breakdown via `--json`                         |
-| `--min-score N`     | Enforced: exit `1` when `scores.overall < N` (`N` in `0`–`100`)                                   |
-| `--ci` alone        | Report mode; **no** implicit threshold; exit `0` on successful scan                               |
-| Algorithm stability | Weights / caps are frozen in [scoring.md](scoring.md); retunes require an explicit doc revision   |
+| Surface              | Notes                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| `scoringAvailable`   | `true`                                                                                            |
+| `scores`             | Populated `{ overall, categories, agents }` integers in `[0, 100]` (see [scoring.md](scoring.md)) |
+| Terminal summary     | Prints overall readiness (`N/100`); category/agent breakdown via `--json`                         |
+| `--min-score N`      | Enforced: exit `1` when `scores.overall < N` (`N` in `0`–`100`); Unreleased also fails when analysis is `limited` |
+| `--fail-on-severity` | Unreleased: exit `1` when any finding is at/above the given severity                                |
+| `--fail-on-rule`     | Unreleased: exit `1` when any finding matches a listed rule id                                      |
+| `--ci` (scan)        | Published `0.3.0-beta`: report-only. Unreleased: exit `1` on any **critical** finding (override with `--fail-on-severity`) |
+| Algorithm stability  | Weights / caps are frozen in [scoring.md](scoring.md); retunes require an explicit doc revision   |
 
 ## Fix + Verify
 
-| Surface             | Notes                                                                                          |
-| ------------------- | ---------------------------------------------------------------------------------------------- |
-| `fix`               | Applies **safe** Cursor `.cursorignore` exclusions for context findings; review/manual skipped |
-| `verify`            | Compares a re-scan to a prior `scan --json` baseline (`fixed` / `remaining` / `new`)           |
-| `verify --ci`       | Exit `1` when **new** findings appear relative to the baseline                                 |
-| Finding `id` values | Stable for compare when evidence paths are unchanged; may change if evidence keys change       |
+| Surface                         | Notes                                                                                                                                                          |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fix`                           | Published `0.3.0-beta`: safe Cursor `.cursorignore` only. Unreleased: also Claude Code `permissions.deny` Read and Codex filesystem deny for context findings; review/manual skipped |
+| `verify`                        | Compares a re-scan to a prior `scan --json` baseline (`fixed` / `remaining` / `new`)                                                                           |
+| `verify --ci` / `--fail-on-new` | Exit `1` when **new** findings appear relative to the baseline (`--fail-on-new` Unreleased)                                                                   |
+| Finding `id` values             | Stable for compare when evidence paths are unchanged; may change if evidence keys change                                                                       |
 
 ## Explicitly unstable / reserved
 
 | Surface                          | Notes                                                    |
 | -------------------------------- | -------------------------------------------------------- |
-| Non-Cursor fix writers           | Claude Code / Codex writers not implemented yet          |
+| Additional fix writers           | Security / review-manual remediations remain non-auto    |
 | Re-exports beyond documented API | Prefer documented exports; others may tighten before 1.0 |
-| GitHub Action score gates        | Action remains `--ci --json` report-only                 |
 
 ## Breaking-change policy
 

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -13,9 +13,11 @@ AgentDoctor uses stable exit codes for CI:
 
 Readiness scoring is available (`scoringAvailable: true`, `scores` populated). Behavior:
 
-- No `--min-score` → exit `0` on successful scan (findings do not change the exit code).
-- `--ci` without `--min-score` → report mode; still exit `0` on successful scan.
-- `--min-score N` (with or without `--ci`) → exit `1` if `scores.overall < N`.
+- No policy flags → exit `0` on successful scan (findings do not change the exit code).
+- `--ci` → exit `1` when any **critical** finding exists (override severity with `--fail-on-severity`).
+- `--min-score N` → exit `1` if `scores.overall < N`, or if no supported agents are configured (`agentSecurityAnalysis: limited`).
+- `--fail-on-severity <critical|warning|info>` → exit `1` if any finding is at or above that severity.
+- `--fail-on-rule <id>` → exit `1` if any finding matches a listed rule id (repeatable / comma-separated).
 
 ## `verify`
 
@@ -23,13 +25,14 @@ Compares a prior `scan --json` baseline to a fresh scan of the same repository.
 
 - Requires a baseline file (`--baseline`, or `agentdoctor-report.json` / `.agentdoctor-baseline.json` in the repo root).
 - `--min-score N` → exit `1` if post-verify `scores.overall < N`.
-- `--ci` → exit `1` when **new** findings appear that were not in the baseline (regressions).
+- `--ci` or `--fail-on-new` → exit `1` when **new** findings appear that were not in the baseline (regressions).
+- `--fail-on-severity` / `--fail-on-rule` apply to the post-verify finding set.
 - Remaining findings from the baseline do not fail the process by themselves (manual/review items are expected).
 
 Example:
 
 ```bash
-npx @praneeth_54/agentdoctor --ci --json --min-score 70
+npx @praneeth_54/agentdoctor --ci --json --min-score 70 --fail-on-severity critical
 echo $?
 
 npx @praneeth_54/agentdoctor scan --json > agentdoctor-report.json
@@ -39,3 +42,7 @@ echo $?
 ```
 
 Related: [scoring.md](scoring.md) · [architecture.md](architecture.md) · [rules.md](rules.md) · [compatibility.md](compatibility.md)
+
+> **Published `0.3.0-beta`:** `--ci` on scan is report-only (no critical gate).
+> `--fail-on-severity` / `--fail-on-rule` are not accepted. Use `--min-score` to fail CI.
+> Behaviors above match this repository’s Unreleased CLI.

--- a/docs/launch/linkedin.md
+++ b/docs/launch/linkedin.md
@@ -24,4 +24,4 @@ npx @praneeth_54/agentdoctor
 GitHub: https://github.com/pranee54/AgentDoctor  
 npm: https://www.npmjs.com/package/@praneeth_54/agentdoctor
 
-It is a public beta — readiness scores ship in JSON (`--min-score` is enforced; `--ci` alone stays report-only). Automatic fixes are not available yet. I would appreciate feedback, especially false positives and misses from real agent setups.
+It is a public beta — readiness scores ship in JSON and the terminal (`--min-score` is enforced). Published `0.3.0-beta`: `--ci` alone stays report-only; `agentdoctor fix` applies safe Cursor `.cursorignore` context exclusions. I would appreciate feedback, especially false positives and misses from real agent setups.

--- a/docs/launch/reddit.md
+++ b/docs/launch/reddit.md
@@ -26,7 +26,7 @@ Design choices:
 - stable rule IDs + JSON for CI
 - intentionally conservative security findings
 
-Not included yet: auto-fix, and GitHub Action score-gate inputs (Action is report-only; CLI `--min-score` works today). Readiness scores ship in JSON.
+Published `0.3.0-beta` includes Cursor `.cursorignore` safe-context Fix and CLI `--min-score`. `--ci` alone stays report-only; GitHub Action `@v0.3.0-beta` is report-only (no score-gate inputs yet). Readiness scores ship in JSON and the terminal.
 
 ```bash
 npx @praneeth_54/agentdoctor

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -36,7 +36,7 @@ Exact token savings are never claimed.
 - **Semantics:** repository risk is reported even when no supported agent is configured (`affectedAgents` empty); agent exposure is asserted only for configured/detected agents without a clear exclusion
 - **Templates:** `.env.example`, `.env.sample`, `.env.template`, `.env.dist` are informational (filename classification only)
 - **Why:** Credentials may enter model context when agents can read the file; tracked/shared env files remain high-risk repository material either way
-- **Agents:** Cursor only if not covered by `.cursorignore` / `.gitignore` / documented default `.env*` ignore; Claude Code unless a Read deny exists; Codex when detected
+- **Agents:** Cursor only if not covered by `.cursorignore` / `.gitignore` / documented default `.env*` ignore; Claude Code unless a Read deny exists; Codex unless a filesystem deny exists in `.codex/config.toml`
 - **False positives:** Cursor’s documented default `.env*` ignore means Cursor is often not listed for agent exposure
 - **Fixability:** review
 
@@ -75,14 +75,15 @@ Exact token savings are never claimed.
 ### `context/large-log-file`
 
 - **Severity:** info
-- **Detects:** Large `*.log` / dump-like files not already ignored
+- **Detects:** Large `*.log` / dump-like files not already ignored (including files larger than the content-read size limit; size is taken from metadata without reading contents)
 - **Fixability:** safe
 
 ### `context/generated-directory`
 
 - **Severity:** info
 - **Detects:** Common generated directories with exact repository-relative evidence (e.g. `mobile-apps/build`) when no matching ignore pattern applies
-- **Ignores:** Root and nested `.gitignore` / `.cursorignore`, including `build/` and `**/build/`
+- **Ignores:** Root and nested `.gitignore` / `.cursorignore`, including `build/` and `**/build/`; Claude Code `permissions.deny` Read rules (`Read(./path/**)`); Codex filesystem deny keys in `.codex/config.toml`
+- **Fix:** `agentdoctor fix` can append `.cursorignore` patterns, Claude Code Read deny rules, and/or Codex filesystem deny keys
 - **Note:** `vendor/` only flagged outside PHP/Composer
 - **Fixability:** safe
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -25,22 +25,22 @@ revision explicitly supersedes it.
 - Secret-content scanning as part of scoring.
 - Treating the score as security certification.
 - Scoring from repository size, file counts, timing, or popularity.
-- Shipping GitHub Action `min-score` / severity-gate inputs in the first scoring release.
 
 ---
 
 ## Shipped v1 behavior
 
-| Surface                       | Behavior                                                             |
-| ----------------------------- | -------------------------------------------------------------------- |
-| `scoringAvailable`            | `true`                                                               |
-| `scores`                      | Populated `{ overall, categories, agents }`                          |
-| `--min-score N`               | Exit `1` if `scores.overall < N`                                     |
-| `--ci` without `--min-score`  | Report mode; exit `0` on successful scan (**no** implicit threshold) |
-| Successful scan with findings | Exit code `0` unless a `--min-score` threshold fails                 |
-| Exit code `1`                 | Score threshold failure (`--min-score`)                              |
-| Terminal                      | Does not render a readiness score (JSON only in v1)                  |
-| GitHub Action                 | Runs `--ci --json` only (report generator; no score-gate inputs yet) |
+| Surface                      | Behavior                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------ |
+| `scoringAvailable`           | `true`                                                                                           |
+| `scores`                     | Populated `{ overall, categories, agents }`                                                      |
+| `--min-score N`              | Exit `1` if `scores.overall < N`, or if analysis is `limited` (no supported agents)              |
+| `--ci` (this repository)     | Exit `1` on any **critical** finding (override with `--fail-on-severity`)                        |
+| `--ci` (published `0.3.0-beta`) | Report-only; exit `0` on successful scan unless `--min-score` fails                           |
+| Successful scan with findings | Exit code `0` unless a policy / threshold gate fails                                            |
+| Exit code `1`                | Policy / threshold / CI gate failure                                                             |
+| Terminal                     | Prints overall readiness (`N/100`, or `n/a` when analysis is limited); category/agent via JSON   |
+| GitHub Action                | Published `@v0.3.0-beta` report-only; Unreleased Action adds policy inputs (see README / CHANGELOG) |
 
 Production scoring uses `computeReadinessScores` (pure function of post-dedupe findings).
 An internal `filesScanned`-based placeholder exists for historical unit tests only and
@@ -155,7 +155,9 @@ When `agentSecurityAnalysis` is `limited` (no supported agent detected/configure
 - Repository-risk findings still deduct and still trigger security caps.
 - Empty `affectedAgents` is expected for some findings; those findings still affect
   overall and category scores.
-- v1 does **not** apply an overall penalty merely because no agents are configured.
+- Terminal readiness prints **n/a** (scores remain in JSON for repository-risk only).
+- `--min-score N` / Action `minimum-score` **fail** when analysis is `limited` — an
+  empty or agentless tree must not pass a CI readiness gate with a vacuous 100.
 
 ---
 
@@ -163,12 +165,13 @@ When `agentSecurityAnalysis` is `limited` (no supported agent detected/configure
 
 With `scoringAvailable === true` and `scores` non-null:
 
-| Invocation                   | Behavior                                                             |
-| ---------------------------- | -------------------------------------------------------------------- |
-| No `--ci`, no `--min-score`  | Exit `0` on successful scan; scores present in JSON                  |
-| `--min-score N`              | Exit `1` if `scores.overall < N`                                     |
-| `--ci` without `--min-score` | Exit `0` on successful scan (report mode; **no** implicit threshold) |
-| `--ci --min-score N`         | Enforce threshold                                                    |
+| Invocation                  | Behavior                                                                     |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| No `--ci`, no `--min-score` | Exit `0` on successful scan; scores present in JSON                          |
+| `--min-score N`             | Exit `1` if `scores.overall < N`, or if analysis is `limited`                |
+| `--ci`                      | Exit `1` if any critical finding exists (override with `--fail-on-severity`) |
+| `--ci` without other gates  | Still enforces the critical severity gate                                    |
+| `--ci --min-score N`        | Enforces critical findings **and** the score threshold                       |
 
 `N` must be a number from **0** to **100** (already validated by the CLI).
 
@@ -218,12 +221,9 @@ Given the same AgentDoctor version and the same post-dedupe finding set:
 
 - Additive JSON such as `scoringModel` or `scoreExplanation`
 - Soft cap for security warnings
-- Terminal “Readiness: N/100” line
-- Overall penalty for “no agents configured”
+- Overall score penalty for “no agents configured” (CLI `--min-score` already fails when analysis is `limited`)
 - Per-agent `not_configured` status fields
 - Category-level security caps
-- GitHub Action `min-score` / severity-gate inputs
-- Fail-on-critical independent of the numeric score
 - Programmatic threshold enforcement inside `scan()` (CLI-only for v1)
 - Weight retunes without an explicit spec revision
 

--- a/src/cli/commands/explain.ts
+++ b/src/cli/commands/explain.ts
@@ -45,7 +45,7 @@ export async function runExplainCommand(ruleId: string | undefined): Promise<Exi
   lines.push(colors.bold("Can AgentDoctor safely fix it?"));
   lines.push(
     rule.fixability === "safe"
-      ? "  Yes for Cursor context exclusions (`agentdoctor fix`). Other agents may still need a manual step."
+      ? "  Yes for Cursor (`.cursorignore`), Claude Code (Read deny in `.claude/settings.json`), and Codex (filesystem deny in `.codex/config.toml`)."
       : rule.fixability === "review"
         ? "  No — requires human review. Fix reports why and leaves the file unchanged."
         : rule.fixability === "manual"

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -1,7 +1,12 @@
 import { EXIT_CODES, type ExitCode } from "../../types/index.js";
 import { isDirectory } from "../../utils/fs.js";
 import { resolveRepoRoot } from "../../utils/path.js";
-import { applyFixPlan, readCursorignore } from "../../core/fix/apply.js";
+import {
+  applyFixPlan,
+  readClaudeSettings,
+  readCodexConfig,
+  readCursorignore,
+} from "../../core/fix/apply.js";
 import { buildFixPlan } from "../../core/fix/plan.js";
 import { renderFixPlanTerminal } from "../../core/fix/render.js";
 import { runFix } from "../../core/fix/run.js";
@@ -33,11 +38,15 @@ export async function runFixCommand(options: FixCommandOptions): Promise<ExitCod
       const result = await scan({ cwd: target });
       const plan = await buildFixPlan(result);
       const cursorContent = await readCursorignore(plan.root);
+      const claudeSettingsContent = await readClaudeSettings(plan.root);
+      const codexConfigContent = await readCodexConfig(plan.root);
       const applyResult = await applyFixPlan(plan, { dryRun: true });
       process.stdout.write(
         renderFixPlanTerminal(plan, {
           dryRun: true,
           cursorContent,
+          claudeSettingsContent,
+          codexConfigContent,
           applyResult,
         }),
       );
@@ -52,31 +61,31 @@ export async function runFixCommand(options: FixCommandOptions): Promise<ExitCod
 
     if (cancelled) {
       process.stdout.write("\n  Cancelled. No files were modified.\n\n");
-      return EXIT_CODES.SUCCESS;
+      return EXIT_CODES.USAGE_ERROR;
     }
 
     const cursorContentAfter = await readCursorignore(plan.root);
+    const claudeSettingsAfter = await readClaudeSettings(plan.root);
+    const codexConfigAfter = await readCodexConfig(plan.root);
     process.stdout.write(
       renderFixPlanTerminal(plan, {
         dryRun: false,
         cursorContent: cursorContentAfter,
+        claudeSettingsContent: claudeSettingsAfter,
+        codexConfigContent: codexConfigAfter,
         applyResult,
       }),
     );
 
-    // After apply, show a short re-scan hint / delta for Cursor-fixable rules
     if (applyResult.writtenFiles.length > 0) {
       const after = await scan({ cwd: target });
       const remainingSafeContext = after.findings.filter(
         (f) =>
           f.fixability === "safe" &&
-          (f.ruleId === "context/generated-directory" || f.ruleId === "context/large-log-file") &&
-          f.affectedAgents.includes("cursor"),
+          (f.ruleId === "context/generated-directory" || f.ruleId === "context/large-log-file"),
       );
       process.stdout.write(
-        colors.dim(
-          `  Re-scan: ${remainingSafeContext.length} Cursor-related safe context finding(s) remain.\n\n`,
-        ),
+        colors.dim(`  Re-scan: ${remainingSafeContext.length} safe context finding(s) remain.\n\n`),
       );
     }
 
@@ -84,6 +93,19 @@ export async function runFixCommand(options: FixCommandOptions): Promise<ExitCod
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Error: ${message}`);
+    if (isFixConfigOrPermissionError(message)) {
+      return EXIT_CODES.USAGE_ERROR;
+    }
     return EXIT_CODES.INTERNAL_ERROR;
   }
+}
+
+function isFixConfigOrPermissionError(message: string): boolean {
+  return (
+    message.includes("refusing") ||
+    message.includes("not valid JSON") ||
+    message.includes("EACCES") ||
+    message.includes("EPERM") ||
+    message.includes("permission denied")
+  );
 }

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -1,11 +1,13 @@
 import path from "node:path";
 
+import { evaluateScanPolicy, type PolicyOptions } from "../../core/policy/evaluate.js";
 import { scan } from "../../core/scanner/scan.js";
+import { emitGithubReports } from "../../reporters/github/emit.js";
 import { renderJsonReport } from "../../reporters/json/report.js";
 import { renderTerminalReport } from "../../reporters/terminal/report.js";
 import { EXIT_CODES, type ExitCode } from "../../types/index.js";
-import { resolveRepoRoot } from "../../utils/path.js";
 import { isDirectory } from "../../utils/fs.js";
+import { resolveRepoRoot } from "../../utils/path.js";
 
 export interface ScanCommandOptions {
   targetPath?: string;
@@ -13,6 +15,10 @@ export interface ScanCommandOptions {
   ci?: boolean;
   verbose?: boolean;
   minScore?: number;
+  failOnSeverity?: PolicyOptions["failOnSeverity"];
+  failOnRules?: string[];
+  summary?: boolean;
+  annotations?: boolean;
 }
 
 export async function runScanCommand(options: ScanCommandOptions): Promise<ExitCode> {
@@ -39,15 +45,32 @@ export async function runScanCommand(options: ScanCommandOptions): Promise<ExitC
       );
     }
 
-    if (options.minScore !== undefined && result.scores !== null) {
-      if (result.scores.overall < options.minScore) {
-        if (!options.json) {
-          console.error(
-            `\nCI check failed: overall score ${result.scores.overall} is below --min-score ${options.minScore}`,
-          );
+    const failOnSeverity = options.failOnSeverity ?? (options.ci === true ? "critical" : undefined);
+    const policy = {
+      ...(options.minScore !== undefined ? { minimumScore: options.minScore } : {}),
+      ...(failOnSeverity !== undefined ? { failOnSeverity } : {}),
+      ...(options.failOnRules && options.failOnRules.length > 0
+        ? { failOnRules: options.failOnRules }
+        : {}),
+    };
+    const violations = evaluateScanPolicy(result, policy);
+
+    await emitGithubReports({
+      mode: "scan",
+      findings: result.findings,
+      overallScore: result.scores?.overall ?? null,
+      violations,
+      summary: options.summary === true,
+      annotations: options.annotations === true,
+    });
+
+    if (violations.length > 0) {
+      if (!options.json) {
+        for (const violation of violations) {
+          console.error(`\n${violation.message}`);
         }
-        return EXIT_CODES.ISSUES_OR_THRESHOLD;
       }
+      return EXIT_CODES.ISSUES_OR_THRESHOLD;
     }
 
     return EXIT_CODES.SUCCESS;

--- a/src/cli/commands/verify.ts
+++ b/src/cli/commands/verify.ts
@@ -1,4 +1,6 @@
+import { evaluateVerifyPolicy, type PolicyOptions } from "../../core/policy/evaluate.js";
 import { verify } from "../../core/verify/verify.js";
+import { emitGithubReports } from "../../reporters/github/emit.js";
 import { renderVerifyJsonReport } from "../../reporters/verify/json.js";
 import { renderVerifyTerminalReport } from "../../reporters/verify/terminal.js";
 import { EXIT_CODES, type ExitCode } from "../../types/index.js";
@@ -12,6 +14,11 @@ export interface VerifyCommandOptions {
   ci?: boolean;
   verbose?: boolean;
   minScore?: number;
+  failOnSeverity?: PolicyOptions["failOnSeverity"];
+  failOnRules?: string[];
+  failOnNew?: boolean;
+  summary?: boolean;
+  annotations?: boolean;
 }
 
 /**
@@ -38,23 +45,32 @@ export async function runVerifyCommand(options: VerifyCommandOptions): Promise<E
       process.stdout.write(renderVerifyTerminalReport(result, options.verbose === true));
     }
 
-    if (options.minScore !== undefined && result.scores !== null) {
-      if (result.scores.overall < options.minScore) {
-        if (!options.json) {
-          console.error(
-            `\nCI check failed: overall score ${result.scores.overall} is below --min-score ${options.minScore}`,
-          );
-        }
-        return EXIT_CODES.ISSUES_OR_THRESHOLD;
-      }
-    }
+    const failOnNew = options.failOnNew === true || options.ci === true;
+    const policy = {
+      ...(options.minScore !== undefined ? { minimumScore: options.minScore } : {}),
+      ...(options.failOnSeverity !== undefined ? { failOnSeverity: options.failOnSeverity } : {}),
+      ...(options.failOnRules && options.failOnRules.length > 0
+        ? { failOnRules: options.failOnRules }
+        : {}),
+      ...(failOnNew ? { failOnNew: true } : {}),
+    };
+    const violations = evaluateVerifyPolicy(result, policy);
 
-    // In CI, newly introduced findings are regressions after Fix.
-    if (options.ci === true && result.summary.new > 0) {
+    await emitGithubReports({
+      mode: "verify",
+      findings: result.after.findings,
+      overallScore: result.scores?.overall ?? null,
+      violations,
+      verifySummary: result.summary,
+      summary: options.summary === true,
+      annotations: options.annotations === true,
+    });
+
+    if (violations.length > 0) {
       if (!options.json) {
-        console.error(
-          `\nCI check failed: verify found ${result.summary.new} new finding(s) not present in the baseline`,
-        );
+        for (const violation of violations) {
+          console.error(`\n${violation.message}`);
+        }
       }
       return EXIT_CODES.ISSUES_OR_THRESHOLD;
     }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,17 +1,18 @@
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 
 import { PACKAGE_VERSION } from "../constants.js";
+import { parseFailOnRules, parseSeverityGate } from "../core/policy/evaluate.js";
+import { EXIT_CODES } from "../types/index.js";
 import { runDoctorCommand } from "./commands/doctor.js";
 import { runExplainCommand } from "./commands/explain.js";
 import { runFixCommand } from "./commands/fix.js";
 import { resolveTargetArgument, runScanCommand } from "./commands/scan.js";
 import { runVerifyCommand } from "./commands/verify.js";
-import { EXIT_CODES } from "../types/index.js";
 
 function parseMinScore(value: string): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed < 0 || parsed > 100) {
-    throw new Error("--min-score must be a number between 0 and 100");
+    throw new InvalidArgumentError("--min-score must be a number between 0 and 100");
   }
   return parsed;
 }
@@ -26,6 +27,29 @@ function readMinScore(options: { minScore?: unknown }): number | undefined {
   return undefined;
 }
 
+function collectFailOnRules(value: string, previous: string[]): string[] {
+  return [...previous, ...parseFailOnRules(value)];
+}
+
+function readFailOnSeverity(options: {
+  failOnSeverity?: unknown;
+}): ReturnType<typeof parseSeverityGate> | undefined {
+  if (typeof options.failOnSeverity !== "string" || options.failOnSeverity.length === 0) {
+    return undefined;
+  }
+  return parseSeverityGate(options.failOnSeverity);
+}
+
+function readFailOnRules(options: { failOnRule?: unknown }): string[] {
+  if (Array.isArray(options.failOnRule)) {
+    return options.failOnRule.filter((item): item is string => typeof item === "string");
+  }
+  if (typeof options.failOnRule === "string") {
+    return parseFailOnRules(options.failOnRule);
+  }
+  return [];
+}
+
 /**
  * Scan flags are declared on both the root program and the `scan` subcommand
  * so `--help` stays accurate. Commander stores overlapping flags on the parent
@@ -34,13 +58,34 @@ function readMinScore(options: { minScore?: unknown }): number | undefined {
 function addScanOptions(command: Command): Command {
   return command
     .option("--json", "Emit machine-readable JSON (no decorative output)", false)
-    .option("--ci", "CI mode (non-interactive; report-only unless --min-score is set)", false)
+    .option(
+      "--ci",
+      "CI mode: exit 1 when any critical finding exists (override with --fail-on-severity)",
+      false,
+    )
     .option("--verbose", "Show timing and extra diagnostics", false)
     .option(
       "--min-score <number>",
       "Exit 1 when overall readiness score is below this (0-100)",
       parseMinScore,
-    );
+    )
+    .option(
+      "--fail-on-severity <level>",
+      "Exit 1 when any finding has this severity or higher (critical|warning|info)",
+      parseSeverityGate,
+    )
+    .option(
+      "--fail-on-rule <id>",
+      "Exit 1 when a finding matches this rule id (repeatable or comma-separated)",
+      collectFailOnRules,
+      [],
+    )
+    .option(
+      "--summary",
+      "Write a GitHub Actions step summary when GITHUB_STEP_SUMMARY is set",
+      false,
+    )
+    .option("--annotations", "Emit GitHub Actions annotations for findings (stderr)", false);
 }
 
 async function runScanFromCli(pathArg: string | undefined, command: Command): Promise<void> {
@@ -49,14 +94,24 @@ async function runScanFromCli(pathArg: string | undefined, command: Command): Pr
     ci?: boolean;
     verbose?: boolean;
     minScore?: unknown;
+    failOnSeverity?: unknown;
+    failOnRule?: unknown;
+    summary?: boolean;
+    annotations?: boolean;
   };
   const minScore = readMinScore(options);
+  const failOnSeverity = readFailOnSeverity(options);
+  const failOnRules = readFailOnRules(options);
   const code = await runScanCommand({
     targetPath: resolveTargetArgument(pathArg),
     json: Boolean(options.json),
     ci: Boolean(options.ci),
     verbose: Boolean(options.verbose),
+    summary: Boolean(options.summary),
+    annotations: Boolean(options.annotations),
     ...(minScore !== undefined ? { minScore } : {}),
+    ...(failOnSeverity !== undefined ? { failOnSeverity } : {}),
+    ...(failOnRules.length > 0 ? { failOnRules } : {}),
   });
   process.exitCode = code;
 }
@@ -87,7 +142,9 @@ export function createProgram(): Command {
 
   program
     .command("fix")
-    .description("Apply safe automatic fixes (Cursor .cursorignore for safe context findings)")
+    .description(
+      "Apply safe automatic fixes (Cursor .cursorignore, Claude Code Read deny, and Codex filesystem deny for safe context findings)",
+    )
     .argument("[path]", "Repository path (default: current directory)")
     .option("--dry-run", "Show proposed fixes without writing files", false)
     .option("-y, --yes", "Skip confirmation prompts", false)
@@ -105,7 +162,12 @@ export function createProgram(): Command {
     .description("Re-scan and compare against a prior scan JSON baseline (Scan → Fix → Verify)")
     .argument("[path]", "Repository path (default: current directory)")
     .option("--json", "Emit machine-readable JSON", false)
-    .option("--ci", "CI mode: exit 1 when new findings appear (also honors --min-score)", false)
+    .option(
+      "--ci",
+      "CI mode: exit 1 when new findings appear (also honors other policy flags)",
+      false,
+    )
+    .option("--fail-on-new", "Exit 1 when new findings appear relative to the baseline", false)
     .option("--verbose", "Show timing and extra diagnostics", false)
     .option(
       "--baseline <file>",
@@ -116,22 +178,51 @@ export function createProgram(): Command {
       "Exit 1 when overall readiness score is below this (0-100)",
       parseMinScore,
     )
+    .option(
+      "--fail-on-severity <level>",
+      "Exit 1 when any finding has this severity or higher (critical|warning|info)",
+      parseSeverityGate,
+    )
+    .option(
+      "--fail-on-rule <id>",
+      "Exit 1 when a finding matches this rule id (repeatable or comma-separated)",
+      collectFailOnRules,
+      [],
+    )
+    .option(
+      "--summary",
+      "Write a GitHub Actions step summary when GITHUB_STEP_SUMMARY is set",
+      false,
+    )
+    .option("--annotations", "Emit GitHub Actions annotations for findings (stderr)", false)
     .action(async (pathArg: string | undefined, _options, command: Command) => {
       const options = command.optsWithGlobals() as {
         json?: boolean;
         ci?: boolean;
+        failOnNew?: boolean;
         verbose?: boolean;
         baseline?: string;
         minScore?: unknown;
+        failOnSeverity?: unknown;
+        failOnRule?: unknown;
+        summary?: boolean;
+        annotations?: boolean;
       };
       const minScore = readMinScore(options);
+      const failOnSeverity = readFailOnSeverity(options);
+      const failOnRules = readFailOnRules(options);
       const code = await runVerifyCommand({
         targetPath: resolveTargetArgument(pathArg),
         json: Boolean(options.json),
         ci: Boolean(options.ci),
+        failOnNew: Boolean(options.failOnNew),
         verbose: Boolean(options.verbose),
+        summary: Boolean(options.summary),
+        annotations: Boolean(options.annotations),
         ...(typeof options.baseline === "string" ? { baselinePath: options.baseline } : {}),
         ...(minScore !== undefined ? { minScore } : {}),
+        ...(failOnSeverity !== undefined ? { failOnSeverity } : {}),
+        ...(failOnRules.length > 0 ? { failOnRules } : {}),
       });
       process.exitCode = code;
     });

--- a/src/core/fix/apply.ts
+++ b/src/core/fix/apply.ts
@@ -1,5 +1,15 @@
 import type { FixApplyResult, FixPlan } from "./types.js";
 import {
+  previewClaudeSettingsActions,
+  readClaudeSettings,
+  writeClaudeSettings,
+} from "./writers/claude-settings.js";
+import {
+  previewCodexConfigActions,
+  readCodexConfig,
+  writeCodexConfig,
+} from "./writers/codex-config.js";
+import {
   previewCursorignoreActions,
   readCursorignore,
   writeCursorignore,
@@ -7,34 +17,54 @@ import {
 
 /**
  * Apply (or dry-run) a fix plan.
- * Week 1: only `.cursorignore` mutations are supported.
+ * Safe writers: `.cursorignore`, Claude settings deny, Codex config.toml deny.
  */
 export async function applyFixPlan(
   plan: FixPlan,
   options: { dryRun: boolean },
 ): Promise<FixApplyResult> {
-  const current = await readCursorignore(plan.root);
-  const preview = previewCursorignoreActions(current, plan.actions);
+  const cursorContent = await readCursorignore(plan.root);
+  const claudeContent = await readClaudeSettings(plan.root);
+  const codexContent = await readCodexConfig(plan.root);
+  const cursorPreview = previewCursorignoreActions(cursorContent, plan.actions);
+  const claudePreview = previewClaudeSettingsActions(claudeContent, plan.actions);
+  const codexPreview = previewCodexConfigActions(codexContent, plan.actions);
 
-  if (!preview) {
-    return {
-      plan,
-      dryRun: options.dryRun,
-      writtenFiles: [],
-      changedFiles: [],
-    };
+  const writtenFiles: string[] = [];
+  const changedFiles: string[] = [];
+
+  if (cursorPreview) {
+    changedFiles.push(cursorPreview.targetRelativePath);
+    if (!options.dryRun) {
+      await writeCursorignore(plan.root, cursorPreview.after);
+      writtenFiles.push(cursorPreview.targetRelativePath);
+    }
   }
 
-  if (!options.dryRun) {
-    await writeCursorignore(plan.root, preview.after);
+  if (claudePreview) {
+    changedFiles.push(claudePreview.targetRelativePath);
+    if (!options.dryRun) {
+      await writeClaudeSettings(plan.root, claudePreview.after);
+      writtenFiles.push(claudePreview.targetRelativePath);
+    }
+  }
+
+  if (codexPreview) {
+    changedFiles.push(codexPreview.targetRelativePath);
+    if (!options.dryRun) {
+      await writeCodexConfig(plan.root, codexPreview.after);
+      writtenFiles.push(codexPreview.targetRelativePath);
+    }
   }
 
   return {
     plan,
     dryRun: options.dryRun,
-    writtenFiles: options.dryRun ? [] : [preview.targetRelativePath],
-    changedFiles: [preview.targetRelativePath],
+    writtenFiles,
+    changedFiles,
   };
 }
 
 export { previewCursorignoreActions, readCursorignore };
+export { previewClaudeSettingsActions, readClaudeSettings };
+export { previewCodexConfigActions, readCodexConfig };

--- a/src/core/fix/plan.ts
+++ b/src/core/fix/plan.ts
@@ -2,14 +2,26 @@ import path from "node:path";
 
 import type { Finding, ScanResult } from "../../types/index.js";
 import { readTextFile } from "../../utils/fs.js";
+import { settingsTextDeniesPath } from "../rules/claude-deny.js";
+import { configTextDeniesPath } from "../rules/codex-deny.js";
 import { createIgnoreIndex, parseIgnoreFile, pathMatchesAny } from "../rules/ignore.js";
 import { isSafeContextFixRule, patternForFinding } from "./patterns.js";
 import type { FixAction, FixPlan, SkippedFix } from "./types.js";
+import { denyRuleForFixPattern } from "./writers/claude-settings.js";
+import { assertWritableCodexConfig, denyKeyForFixPattern } from "./writers/codex-config.js";
 
 const DEFAULT_MAX_IGNORE_BYTES = 512 * 1024;
 
 function cursorConfigured(result: ScanResult): boolean {
   return result.agents.some((a) => a.id === "cursor" && (a.detected || a.configured));
+}
+
+function claudeConfigured(result: ScanResult): boolean {
+  return result.agents.some((a) => a.id === "claude-code" && (a.detected || a.configured));
+}
+
+function codexConfigured(result: ScanResult): boolean {
+  return result.agents.some((a) => a.id === "codex" && (a.detected || a.configured));
 }
 
 async function loadCursorignorePatterns(root: string): Promise<string[]> {
@@ -21,9 +33,17 @@ async function loadCursorignorePatterns(root: string): Promise<string[]> {
   return parseIgnoreFile(text);
 }
 
+async function loadClaudeSettingsText(root: string): Promise<string | null> {
+  return readTextFile(path.join(root, ".claude/settings.json"), DEFAULT_MAX_IGNORE_BYTES);
+}
+
+async function loadCodexConfigText(root: string): Promise<string | null> {
+  return readTextFile(path.join(root, ".codex/config.toml"), DEFAULT_MAX_IGNORE_BYTES);
+}
+
 /**
  * Build a fix plan from a scan result.
- * Week 1: Cursor `.cursorignore` appends for safe context findings only.
+ * Safe context exclusions: Cursor `.cursorignore`, Claude Code Read deny, Codex filesystem deny.
  */
 export async function buildFixPlan(result: ScanResult): Promise<FixPlan> {
   const root = result.repository.root;
@@ -35,8 +55,12 @@ export async function buildFixPlan(result: ScanResult): Promise<FixPlan> {
     gitignorePatterns: [],
     cursorignorePatterns: existingCursorPatterns,
   });
+  const claudeSettingsText = await loadClaudeSettingsText(root);
+  const codexConfigText = await loadCodexConfigText(root);
 
   const hasCursor = cursorConfigured(result);
+  const hasClaude = claudeConfigured(result);
+  const hasCodex = codexConfigured(result);
 
   for (const finding of result.findings) {
     if (finding.fixability !== "safe") {
@@ -74,6 +98,9 @@ export async function buildFixPlan(result: ScanResult): Promise<FixPlan> {
     }
 
     const wantsCursor = finding.affectedAgents.includes("cursor");
+    const wantsClaude = finding.affectedAgents.includes("claude-code");
+    const wantsCodex = finding.affectedAgents.includes("codex");
+
     if (wantsCursor && hasCursor) {
       if (
         cursorIndex.matchesCursorignore(evidencePath) ||
@@ -95,8 +122,51 @@ export async function buildFixPlan(result: ScanResult): Promise<FixPlan> {
       });
     }
 
+    if (wantsClaude && hasClaude) {
+      const denyRule = denyRuleForFixPattern(pattern, evidencePath);
+      if (claudeSettingsText && settingsTextDeniesPath(claudeSettingsText, evidencePath)) {
+        skipped.push({
+          findingId: finding.id,
+          ruleId: finding.ruleId,
+          reason: "Already excluded by Claude Code Read deny",
+        });
+      } else {
+        mergeClaudeAction(actionsByKey, finding, pattern, evidencePath, denyRule);
+      }
+    } else if (wantsClaude && !hasClaude) {
+      skipped.push({
+        findingId: finding.id,
+        ruleId: finding.ruleId,
+        reason: "Claude Code not detected; skipping settings deny fix",
+      });
+    }
+
+    if (wantsCodex && hasCodex) {
+      const denyKey = denyKeyForFixPattern(pattern, evidencePath);
+      if (codexConfigText && configTextDeniesPath(codexConfigText, evidencePath)) {
+        skipped.push({
+          findingId: finding.id,
+          ruleId: finding.ruleId,
+          reason: "Already excluded by Codex filesystem deny",
+        });
+      } else if (codexConfigText) {
+        // Refuse unwritable/invalid config the same way Claude Fix refuses bad JSON —
+        // do not silently skip and leave Codex findings uncleared after a partial Cursor write.
+        assertWritableCodexConfig(codexConfigText);
+        mergeCodexAction(actionsByKey, finding, pattern, evidencePath, denyKey);
+      } else {
+        mergeCodexAction(actionsByKey, finding, pattern, evidencePath, denyKey);
+      }
+    } else if (wantsCodex && !hasCodex) {
+      skipped.push({
+        findingId: finding.id,
+        ruleId: finding.ruleId,
+        reason: "Codex not detected; skipping config.toml deny fix",
+      });
+    }
+
     for (const agent of finding.affectedAgents) {
-      if (agent === "cursor") {
+      if (agent === "cursor" || agent === "claude-code" || agent === "codex") {
         continue;
       }
       skipped.push({
@@ -141,6 +211,62 @@ function mergeCursorAction(
   });
 }
 
+function mergeClaudeAction(
+  actionsByKey: Map<string, FixAction>,
+  finding: Finding,
+  pattern: string,
+  evidencePath: string,
+  denyRule: string,
+): void {
+  const key = `claude-code:.claude/settings.json:${denyRule}`;
+  const existing = actionsByKey.get(key);
+  if (existing) {
+    if (!existing.findingIds.includes(finding.id)) {
+      existing.findingIds.push(finding.id);
+    }
+    return;
+  }
+
+  actionsByKey.set(key, {
+    id: key,
+    kind: "append-ignore-pattern",
+    agent: "claude-code",
+    targetRelativePath: ".claude/settings.json",
+    pattern,
+    evidencePath,
+    findingIds: [finding.id],
+    description: `Exclude ${evidencePath} from Claude Code via permissions.deny ${denyRule}`,
+  });
+}
+
+function mergeCodexAction(
+  actionsByKey: Map<string, FixAction>,
+  finding: Finding,
+  pattern: string,
+  evidencePath: string,
+  denyKey: string,
+): void {
+  const key = `codex:.codex/config.toml:${denyKey}`;
+  const existing = actionsByKey.get(key);
+  if (existing) {
+    if (!existing.findingIds.includes(finding.id)) {
+      existing.findingIds.push(finding.id);
+    }
+    return;
+  }
+
+  actionsByKey.set(key, {
+    id: key,
+    kind: "append-ignore-pattern",
+    agent: "codex",
+    targetRelativePath: ".codex/config.toml",
+    pattern,
+    evidencePath,
+    findingIds: [finding.id],
+    description: `Exclude ${evidencePath} from Codex via filesystem deny "${denyKey}"`,
+  });
+}
+
 /** Patterns that would be newly appended given current file contents. */
 export function missingPatternsForCursorignore(
   currentContent: string | null,
@@ -158,7 +284,6 @@ export function missingPatternsForCursorignore(
     ) {
       continue;
     }
-    // Also skip if an existing pattern already excludes this path
     const evidenceGuess = pattern.endsWith("/") ? pattern.slice(0, -1) : pattern;
     if (pathMatchesAny(evidenceGuess, existing) || pathMatchesAny(pattern, existing)) {
       continue;

--- a/src/core/fix/render.ts
+++ b/src/core/fix/render.ts
@@ -1,4 +1,6 @@
 import type { FixApplyResult, FixPlan } from "./types.js";
+import { previewClaudeSettingsActions } from "./writers/claude-settings.js";
+import { previewCodexConfigActions } from "./writers/codex-config.js";
 import { previewCursorignoreActions } from "./writers/cursorignore.js";
 
 export function renderFixPlanTerminal(
@@ -6,6 +8,8 @@ export function renderFixPlanTerminal(
   options: {
     dryRun: boolean;
     cursorContent: string | null;
+    claudeSettingsContent?: string | null;
+    codexConfigContent?: string | null;
     applyResult?: FixApplyResult;
   },
 ): string {
@@ -24,9 +28,21 @@ export function renderFixPlanTerminal(
         lines.push(`    - ${reason} (${count})`);
       }
       lines.push("");
-      lines.push("  Next: address remaining findings, then run `agentdoctor verify`.");
+      lines.push("Next");
+      lines.push(
+        "  Inspect a finding: agentdoctor explain <rule-id>  (ids in scan --json)",
+      );
+      lines.push(
+        "  Confirm with verify: agentdoctor verify --baseline agentdoctor-report.json",
+      );
+      lines.push(
+        "  No baseline yet? agentdoctor scan --json > agentdoctor-report.json",
+      );
     } else {
       lines.push("  Scan found nothing that Fix can change.");
+      lines.push("");
+      lines.push("Next");
+      lines.push("  Re-scan: agentdoctor scan");
     }
     lines.push("");
     return lines.join("\n");
@@ -39,14 +55,51 @@ export function renderFixPlanTerminal(
     lines.push(`      findings: ${action.findingIds.length}`);
   }
 
-  const preview = previewCursorignoreActions(options.cursorContent, plan.actions);
-  if (preview) {
+  const cursorPreview = previewCursorignoreActions(options.cursorContent, plan.actions);
+  const claudePreview = previewClaudeSettingsActions(
+    options.claudeSettingsContent ?? null,
+    plan.actions,
+  );
+  const codexPreview = previewCodexConfigActions(options.codexConfigContent ?? null, plan.actions);
+
+  if (cursorPreview || claudePreview || codexPreview) {
     lines.push("");
     lines.push("  File changes:");
-    lines.push(`    ${preview.targetRelativePath} (+${preview.patternsToAdd.length} pattern(s))`);
-    lines.push("");
-    for (const previewLine of preview.preview.split("\n")) {
-      lines.push(`  ${previewLine}`);
+    let shown = false;
+    if (cursorPreview) {
+      lines.push(
+        `    ${cursorPreview.targetRelativePath} (+${cursorPreview.patternsToAdd.length} pattern(s))`,
+      );
+      lines.push("");
+      for (const previewLine of cursorPreview.preview.split("\n")) {
+        lines.push(`  ${previewLine}`);
+      }
+      shown = true;
+    }
+    if (claudePreview) {
+      if (shown) {
+        lines.push("");
+      }
+      lines.push(
+        `    ${claudePreview.targetRelativePath} (+${claudePreview.denyRulesToAdd.length} deny rule(s))`,
+      );
+      lines.push("");
+      for (const previewLine of claudePreview.preview.split("\n")) {
+        lines.push(`  ${previewLine}`);
+      }
+      shown = true;
+    }
+    if (codexPreview) {
+      if (shown) {
+        lines.push("");
+      }
+      lines.push(
+        `    ${codexPreview.targetRelativePath} (+${codexPreview.denyKeysToAdd.length} deny key(s))`,
+      );
+      lines.push("");
+      for (const previewLine of codexPreview.preview.split("\n")) {
+        lines.push(`  ${previewLine}`);
+      }
     }
   }
 
@@ -60,14 +113,33 @@ export function renderFixPlanTerminal(
   } else if (options.dryRun) {
     lines.push("");
     lines.push("  No files were modified (dry-run).");
-    lines.push("  Re-run without --dry-run to apply.");
   }
 
   if (plan.skipped.length > 0) {
     lines.push("");
-    lines.push(`  Skipped: ${plan.skipped.length} finding(s) (writers pending or already fixed)`);
+    lines.push(`  Skipped: ${plan.skipped.length} finding(s):`);
+    const reasons = summarizeSkipReasons(plan.skipped.map((s) => s.reason));
+    for (const [reason, count] of reasons) {
+      lines.push(`    - ${reason} (${count})`);
+    }
   }
 
+  lines.push("");
+  lines.push("Next");
+  if (options.dryRun && plan.actions.length > 0) {
+    lines.push("  Apply these changes: agentdoctor fix -y");
+  }
+  if (plan.skipped.length > 0) {
+    lines.push(
+      "  Review/manual findings stay open — inspect with: agentdoctor explain <rule-id>",
+    );
+  }
+  lines.push(
+    "  Confirm with verify: agentdoctor verify --baseline agentdoctor-report.json",
+  );
+  lines.push(
+    "  No baseline yet? agentdoctor scan --json > agentdoctor-report.json",
+  );
   lines.push("");
   return lines.join("\n");
 }

--- a/src/core/fix/run.ts
+++ b/src/core/fix/run.ts
@@ -2,7 +2,7 @@ import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 
 import { scan } from "../scanner/scan.js";
-import { applyFixPlan, readCursorignore } from "./apply.js";
+import { applyFixPlan, readClaudeSettings, readCodexConfig, readCursorignore } from "./apply.js";
 import { buildFixPlan } from "./plan.js";
 import { renderFixPlanTerminal } from "./render.js";
 import type { FixApplyResult, FixPlan } from "./types.js";
@@ -26,6 +26,8 @@ export async function runFix(options: RunFixOptions): Promise<RunFixResult> {
   const result = await scan({ cwd: options.cwd });
   const plan = await buildFixPlan(result);
   const cursorContent = await readCursorignore(plan.root);
+  const claudeSettingsContent = await readClaudeSettings(plan.root);
+  const codexConfigContent = await readCodexConfig(plan.root);
 
   if (plan.actions.length === 0 || options.dryRun) {
     const applyResult = await applyFixPlan(plan, { dryRun: true });
@@ -36,6 +38,8 @@ export async function runFix(options: RunFixOptions): Promise<RunFixResult> {
     const previewText = renderFixPlanTerminal(plan, {
       dryRun: true,
       cursorContent,
+      claudeSettingsContent,
+      codexConfigContent,
     });
     process.stdout.write(previewText);
     const confirmed = await confirm("Apply these changes?");

--- a/src/core/fix/types.ts
+++ b/src/core/fix/types.ts
@@ -3,7 +3,11 @@ import type { AgentId } from "../../types/index.js";
 export type FixKind = "append-ignore-pattern";
 
 /** Allowlisted relative paths fix may create or modify. */
-export const FIX_PATH_ALLOWLIST = [".cursorignore"] as const;
+export const FIX_PATH_ALLOWLIST = [
+  ".cursorignore",
+  ".claude/settings.json",
+  ".codex/config.toml",
+] as const;
 
 export type FixAllowlistedPath = (typeof FIX_PATH_ALLOWLIST)[number];
 

--- a/src/core/fix/writers/claude-settings.ts
+++ b/src/core/fix/writers/claude-settings.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { readTextFile } from "../../../utils/fs.js";
+import { claudeReadDenyRule } from "../../rules/claude-deny.js";
+import type { FixAction } from "../types.js";
+
+const MAX_BYTES = 512 * 1024;
+const SETTINGS_RELATIVE = ".claude/settings.json";
+
+export interface ClaudeSettingsWritePreview {
+  targetRelativePath: typeof SETTINGS_RELATIVE;
+  denyRulesToAdd: string[];
+  before: string;
+  after: string;
+  preview: string;
+}
+
+interface ClaudeSettingsJson {
+  permissions?: {
+    deny?: unknown;
+    allow?: unknown;
+    ask?: unknown;
+    defaultMode?: unknown;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export function denyRuleForFixPattern(pattern: string, evidencePath: string): string {
+  const isDirectory = pattern.endsWith("/");
+  return claudeReadDenyRule(evidencePath, isDirectory ? "directory" : "file");
+}
+
+export function missingClaudeDenyRules(
+  currentContent: string | null,
+  denyRules: string[],
+): string[] {
+  const existing = parseDenyList(currentContent);
+  const missing: string[] = [];
+  for (const rule of denyRules) {
+    if (existing.includes(rule)) {
+      continue;
+    }
+    missing.push(rule);
+  }
+  return missing;
+}
+
+export function buildClaudeSettingsContent(
+  currentContent: string | null,
+  denyRulesToAdd: string[],
+): string {
+  if (denyRulesToAdd.length === 0) {
+    return currentContent ?? `${JSON.stringify({ permissions: { deny: [] } }, null, 2)}\n`;
+  }
+
+  let parsed: ClaudeSettingsJson = {};
+  if (currentContent && currentContent.trim().length > 0) {
+    try {
+      parsed = JSON.parse(currentContent) as ClaudeSettingsJson;
+    } catch {
+      throw new Error(`${SETTINGS_RELATIVE} is not valid JSON; refusing to apply Claude Fix`);
+    }
+  }
+
+  const permissions =
+    parsed.permissions && typeof parsed.permissions === "object" ? { ...parsed.permissions } : {};
+  const deny = Array.isArray(permissions.deny)
+    ? permissions.deny.filter((item): item is string => typeof item === "string")
+    : [];
+
+  for (const rule of denyRulesToAdd) {
+    if (!deny.includes(rule)) {
+      deny.push(rule);
+    }
+  }
+
+  permissions.deny = deny;
+  parsed.permissions = permissions;
+
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+export function previewClaudeSettingsActions(
+  currentContent: string | null,
+  actions: FixAction[],
+): ClaudeSettingsWritePreview | null {
+  const claudeActions = actions.filter(
+    (a) => a.agent === "claude-code" && a.targetRelativePath === SETTINGS_RELATIVE,
+  );
+  if (claudeActions.length === 0) {
+    return null;
+  }
+
+  const requested = [
+    ...new Set(claudeActions.map((a) => denyRuleForFixPattern(a.pattern, a.evidencePath))),
+  ];
+  const denyRulesToAdd = missingClaudeDenyRules(currentContent, requested);
+  if (denyRulesToAdd.length === 0) {
+    return null;
+  }
+
+  const before = currentContent ?? "";
+  const after = buildClaudeSettingsContent(currentContent, denyRulesToAdd);
+  return {
+    targetRelativePath: SETTINGS_RELATIVE,
+    denyRulesToAdd,
+    before,
+    after,
+    preview: formatSimpleDiff(SETTINGS_RELATIVE, before, after),
+  };
+}
+
+export async function readClaudeSettings(root: string): Promise<string | null> {
+  return readTextFile(path.join(root, SETTINGS_RELATIVE), MAX_BYTES);
+}
+
+export async function writeClaudeSettings(root: string, content: string): Promise<void> {
+  const target = path.join(root, SETTINGS_RELATIVE);
+  const dir = path.dirname(target);
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = path.join(dir, `.settings.json.agentdoctor.${process.pid}.tmp`);
+  await fs.writeFile(tmp, content, "utf8");
+  await fs.rename(tmp, target);
+}
+
+function parseDenyList(currentContent: string | null): string[] {
+  if (!currentContent || currentContent.trim().length === 0) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(currentContent) as ClaudeSettingsJson;
+    const deny = parsed.permissions?.deny;
+    if (!Array.isArray(deny)) {
+      return [];
+    }
+    return deny.filter((item): item is string => typeof item === "string");
+  } catch {
+    return [];
+  }
+}
+
+function formatSimpleDiff(fileLabel: string, before: string, after: string): string {
+  const lines: string[] = [];
+  lines.push(`--- a/${fileLabel}`);
+  lines.push(`+++ b/${fileLabel}`);
+  lines.push(before.trim().length === 0 ? "@@ new file @@" : "@@ update @@");
+  for (const line of after.split(/\r?\n/)) {
+    lines.push(`+${line}`);
+  }
+  return lines.join("\n");
+}

--- a/src/core/fix/writers/codex-config.ts
+++ b/src/core/fix/writers/codex-config.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { readTextFile } from "../../../utils/fs.js";
+import { codexDenyKey, configTextDeniesPath } from "../../rules/codex-deny.js";
+import type { FixAction } from "../types.js";
+
+const MAX_BYTES = 512 * 1024;
+const CONFIG_RELATIVE = ".codex/config.toml";
+const AGENTDOCTOR_PROFILE = "agentdoctor_context";
+const BEGIN_MARKER = "# BEGIN AgentDoctor context exclusions";
+const END_MARKER = "# END AgentDoctor context exclusions";
+
+export interface CodexConfigWritePreview {
+  targetRelativePath: typeof CONFIG_RELATIVE;
+  denyKeysToAdd: string[];
+  before: string;
+  after: string;
+  preview: string;
+}
+
+export function denyKeyForFixPattern(_pattern: string, evidencePath: string): string {
+  return codexDenyKey(evidencePath);
+}
+
+export function missingCodexDenyKeys(currentContent: string | null, denyKeys: string[]): string[] {
+  if (!currentContent || currentContent.trim().length === 0) {
+    return [...new Set(denyKeys)];
+  }
+  const missing: string[] = [];
+  for (const key of denyKeys) {
+    if (configTextDeniesPath(currentContent, key)) {
+      continue;
+    }
+    missing.push(key);
+  }
+  return [...new Set(missing)];
+}
+
+/**
+ * Merge filesystem deny keys into project `.codex/config.toml`.
+ * Refuses when sandbox_mode is present (permission profiles do not compose).
+ * Refuses when default_permissions selects a built-in `:…` profile.
+ */
+export function buildCodexConfigContent(
+  currentContent: string | null,
+  denyKeysToAdd: string[],
+): string {
+  if (denyKeysToAdd.length === 0) {
+    return currentContent ?? "";
+  }
+
+  const existing = currentContent ?? "";
+  assertWritableCodexConfig(existing);
+
+  const profile = resolveTargetProfile(existing);
+  const sectionHeader = `[permissions.${profile}.filesystem.":workspace_roots"]`;
+  let next = existing;
+
+  if (!hasDefaultPermissions(next)) {
+    next = ensureTrailingNewline(next);
+    if (next.trim().length > 0) {
+      next += "\n";
+    }
+    next += `${BEGIN_MARKER}\n`;
+    next += `default_permissions = "${profile}"\n`;
+  }
+
+  const section = findTomlTableRange(next, sectionHeader);
+  if (!section) {
+    next = ensureTrailingNewline(next);
+    if (!next.includes(BEGIN_MARKER)) {
+      next += `\n${BEGIN_MARKER}\n`;
+    }
+    next += `${sectionHeader}\n`;
+    if (profile === AGENTDOCTOR_PROFILE) {
+      next += `"." = "write"\n`;
+    }
+    for (const key of denyKeysToAdd) {
+      next += `"${key}" = "deny"\n`;
+    }
+    if (!next.includes(END_MARKER)) {
+      next += `${END_MARKER}\n`;
+    }
+    return next;
+  }
+
+  const body = next.slice(section.bodyStart, section.end);
+  const linesToInsert: string[] = [];
+  for (const key of denyKeysToAdd) {
+    if (configTextDeniesPath(body, key) || configTextDeniesPath(next, key)) {
+      continue;
+    }
+    linesToInsert.push(`"${key}" = "deny"`);
+  }
+  if (linesToInsert.length === 0) {
+    return next;
+  }
+
+  const beforeBodyEnd = next.slice(0, section.end);
+  const afterBodyEnd = next.slice(section.end);
+  const trimmedBodyEnd = beforeBodyEnd.endsWith("\n") ? beforeBodyEnd : `${beforeBodyEnd}\n`;
+  const suffix =
+    afterBodyEnd.startsWith("\n") || afterBodyEnd.length === 0 ? afterBodyEnd : `\n${afterBodyEnd}`;
+  return `${trimmedBodyEnd}${linesToInsert.join("\n")}\n${suffix}`;
+}
+
+export function previewCodexConfigActions(
+  currentContent: string | null,
+  actions: FixAction[],
+): CodexConfigWritePreview | null {
+  const codexActions = actions.filter(
+    (a) => a.agent === "codex" && a.targetRelativePath === CONFIG_RELATIVE,
+  );
+  if (codexActions.length === 0) {
+    return null;
+  }
+
+  const requested = [
+    ...new Set(codexActions.map((a) => denyKeyForFixPattern(a.pattern, a.evidencePath))),
+  ];
+  const denyKeysToAdd = missingCodexDenyKeys(currentContent, requested);
+  if (denyKeysToAdd.length === 0) {
+    return null;
+  }
+
+  const before = currentContent ?? "";
+  const after = buildCodexConfigContent(currentContent, denyKeysToAdd);
+  return {
+    targetRelativePath: CONFIG_RELATIVE,
+    denyKeysToAdd,
+    before,
+    after,
+    preview: formatSimpleDiff(CONFIG_RELATIVE, before, after),
+  };
+}
+
+export async function readCodexConfig(root: string): Promise<string | null> {
+  return readTextFile(path.join(root, CONFIG_RELATIVE), MAX_BYTES);
+}
+
+export async function writeCodexConfig(root: string, content: string): Promise<void> {
+  const target = path.join(root, CONFIG_RELATIVE);
+  const dir = path.dirname(target);
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = path.join(dir, `.config.toml.agentdoctor.${process.pid}.tmp`);
+  await fs.writeFile(tmp, content, "utf8");
+  await fs.rename(tmp, target);
+}
+
+export function assertWritableCodexConfig(content: string): void {
+  if (/^\s*sandbox_mode\s*=/m.test(content)) {
+    throw new Error(
+      `${CONFIG_RELATIVE} uses sandbox_mode; refusing Codex Fix (permission profiles do not compose with sandbox_mode)`,
+    );
+  }
+  const builtin = readDefaultPermissions(content);
+  if (builtin && builtin.startsWith(":")) {
+    throw new Error(
+      `${CONFIG_RELATIVE} default_permissions is built-in "${builtin}"; refusing Codex Fix (create a custom permissions profile first)`,
+    );
+  }
+  if (content.trim().length > 0 && !isRecognizableCodexConfig(content)) {
+    throw new Error(
+      `${CONFIG_RELATIVE} does not look like valid Codex config TOML; refusing Codex Fix`,
+    );
+  }
+}
+
+/** Allow empty/comment-only files, AgentDoctor-managed blocks, or known Codex tables. */
+function isRecognizableCodexConfig(content: string): boolean {
+  if (content.includes(BEGIN_MARKER) || content.includes(END_MARKER)) {
+    return true;
+  }
+  if (readDefaultPermissions(content) !== null) {
+    return true;
+  }
+  if (/^\s*\[(permissions\.|mcp_servers\.|projects\.)/m.test(content)) {
+    return true;
+  }
+  // Comment-only / blank files are safe to initialize.
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+function resolveTargetProfile(content: string): string {
+  const existing = readDefaultPermissions(content);
+  if (existing && !existing.startsWith(":")) {
+    return existing;
+  }
+  return AGENTDOCTOR_PROFILE;
+}
+
+function hasDefaultPermissions(content: string): boolean {
+  return readDefaultPermissions(content) !== null;
+}
+
+function readDefaultPermissions(content: string): string | null {
+  const match = content.match(/^\s*default_permissions\s*=\s*["']([^"']+)["']\s*$/m);
+  return match?.[1] ?? null;
+}
+
+function findTomlTableRange(
+  content: string,
+  header: string,
+): { start: number; bodyStart: number; end: number } | null {
+  const start = content.indexOf(header);
+  if (start < 0) {
+    return null;
+  }
+  const bodyStart = start + header.length;
+  const rest = content.slice(bodyStart);
+  const nextHeader = rest.search(/\n\s*\[/);
+  const end = nextHeader < 0 ? content.length : bodyStart + nextHeader;
+  return { start, bodyStart, end };
+}
+
+function ensureTrailingNewline(value: string): string {
+  if (value.length === 0 || value.endsWith("\n")) {
+    return value;
+  }
+  return `${value}\n`;
+}
+
+function formatSimpleDiff(fileLabel: string, before: string, after: string): string {
+  const lines: string[] = [];
+  lines.push(`--- a/${fileLabel}`);
+  lines.push(`+++ b/${fileLabel}`);
+  lines.push(before.trim().length === 0 ? "@@ new file @@" : "@@ update @@");
+  for (const line of after.split(/\r?\n/)) {
+    lines.push(`+${line}`);
+  }
+  return lines.join("\n");
+}

--- a/src/core/path-resolution/index.ts
+++ b/src/core/path-resolution/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Path Resolution Engine — shared path reference preparation/resolution.
+ * Stage 1 exports preparation only; later stages extend this surface.
+ */
+
+export {
+  isConcretePathReference,
+  normalizePathReference,
+  preparePathReference,
+  type PathConcreteRejectReason,
+  type PreparedPathReference,
+} from "./prepare.js";

--- a/src/core/path-resolution/prepare.ts
+++ b/src/core/path-resolution/prepare.ts
@@ -1,0 +1,132 @@
+/**
+ * Path Resolution Engine — Stage 1: prepare candidates for deterministic resolution.
+ *
+ * Shared infrastructure. Future stages add lattice resolution; Stage 1 only:
+ * - concrete-only filtering
+ * - URI decoding
+ * - path normalization
+ *
+ * No repository-specific or framework-specific logic.
+ */
+
+export type PathConcreteRejectReason =
+  | "empty"
+  | "placeholder"
+  | "ellipsis"
+  | "home"
+  | "git-ref"
+  | "bundler-module-type"
+  | "undecodable";
+
+export type PreparedPathReference =
+  | {
+      status: "concrete";
+      /** Raw reference as extracted from source text. */
+      original: string;
+      /** Decoded, separator-normalized form used for resolution/existence checks. */
+      normalized: string;
+    }
+  | {
+      status: "reject";
+      original: string;
+      reason: PathConcreteRejectReason;
+    };
+
+/** Angle-bracket or `{name}` template slots — intentional non-paths. */
+const PLACEHOLDER_TOKEN = /(?:<[^<>\s]+>|\{[A-Za-z_][A-Za-z0-9_]*\})/;
+
+/** Ellipsis segments used as documentation wildcards (`bases/base/...`). */
+const ELLIPSIS_SEGMENT = /(^|\/)\.\.\.(\/|$)/;
+
+/**
+ * Git-ref shaped tokens that appear in backticks but are not filesystem paths.
+ * Kept narrow: remote refs + conventional-commit branch prefixes.
+ * Does not treat `docs/` as a branch prefix (collides with documentation trees).
+ * Branch-like prefixes are ignored when the reference ends with a file extension.
+ */
+const REMOTE_REF_SHAPE = /^(?:origin|upstream|HEAD)\/[A-Za-z0-9._/-]+$/;
+const BRANCH_PREFIX_SHAPE = /^(?:feature|fix|chore|hotfix|release)\/[A-Za-z0-9._/-]+$/;
+const FILE_EXTENSION_SUFFIX = /\.[A-Za-z0-9]{1,16}$/;
+
+function looksLikeGitRef(normalized: string): boolean {
+  if (REMOTE_REF_SHAPE.test(normalized)) {
+    return true;
+  }
+  if (!BRANCH_PREFIX_SHAPE.test(normalized)) {
+    return false;
+  }
+  // `fix/login.ts` is a path; `fix/bug-in-worker-threads` is a branch token
+  return !FILE_EXTENSION_SUFFIX.test(normalized);
+}
+
+/**
+ * Bundler module-type tokens (`asset/resource`, `javascript/auto`) — not paths.
+ * Generalized type/name pattern; no bundler product names.
+ */
+const BUNDLER_MODULE_TYPE = /^(?:asset|javascript|css|json|wasm|webassembly|runtime)\/[A-Za-z0-9_-]+$/;
+
+/**
+ * Normalize a path reference for filesystem checks:
+ * URI-decode percent-encoding, unify separators to `/`.
+ * Does not decide concreteness.
+ */
+export function normalizePathReference(raw: string): string | null {
+  if (!raw) {
+    return null;
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+  return decoded.replace(/\\/g, "/");
+}
+
+function concretenessRejectReason(normalized: string): PathConcreteRejectReason | null {
+  if (!normalized) {
+    return "empty";
+  }
+  if (PLACEHOLDER_TOKEN.test(normalized)) {
+    return "placeholder";
+  }
+  if (ELLIPSIS_SEGMENT.test(normalized)) {
+    return "ellipsis";
+  }
+  if (normalized === "~" || normalized.startsWith("~/") || normalized.startsWith("~\\")) {
+    return "home";
+  }
+  if (looksLikeGitRef(normalized)) {
+    return "git-ref";
+  }
+  if (BUNDLER_MODULE_TYPE.test(normalized)) {
+    return "bundler-module-type";
+  }
+  return null;
+}
+
+/**
+ * Stage 1 entry point: filter non-concrete references and normalize survivors.
+ */
+export function preparePathReference(raw: string): PreparedPathReference {
+  const original = raw;
+  if (!original || !original.trim()) {
+    return { status: "reject", original, reason: "empty" };
+  }
+
+  const normalized = normalizePathReference(original.trim());
+  if (normalized === null) {
+    return { status: "reject", original, reason: "undecodable" };
+  }
+
+  const reason = concretenessRejectReason(normalized);
+  if (reason) {
+    return { status: "reject", original, reason };
+  }
+
+  return { status: "concrete", original, normalized };
+}
+
+export function isConcretePathReference(raw: string): boolean {
+  return preparePathReference(raw).status === "concrete";
+}

--- a/src/core/policy/evaluate.ts
+++ b/src/core/policy/evaluate.ts
@@ -1,0 +1,181 @@
+import { InvalidArgumentError } from "commander";
+
+import type { Finding, ScanResult, Scores, Severity } from "../../types/index.js";
+
+export type PolicyViolationCode =
+  "minimum-score" | "fail-on-severity" | "fail-on-rule" | "fail-on-new";
+
+export interface PolicyOptions {
+  /** Fail when overall score is strictly below this value (0–100). */
+  minimumScore?: number;
+  /** Fail when any finding has this severity or higher. */
+  failOnSeverity?: Severity;
+  /** Fail when any finding matches one of these rule IDs. */
+  failOnRules?: string[];
+  /** Fail when verify reports new findings not present in the baseline. */
+  failOnNew?: boolean;
+}
+
+export interface PolicyViolation {
+  code: PolicyViolationCode;
+  message: string;
+  /** Rule IDs or finding IDs related to this violation, when applicable. */
+  details?: string[];
+}
+
+export interface PolicyInput {
+  findings: Finding[];
+  scores: Scores | null;
+  /** Count of new findings from verify; omit for scan-only. */
+  newFindingCount?: number;
+  /** When limited, --min-score cannot be treated as agent-readiness enforcement. */
+  agentSecurityAnalysis?: "full" | "limited";
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+};
+
+export function severityRank(severity: Severity): number {
+  return SEVERITY_RANK[severity];
+}
+
+export function parseSeverityGate(value: string): Severity {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "critical" || normalized === "warning" || normalized === "info") {
+    return normalized;
+  }
+  throw new InvalidArgumentError(
+    `--fail-on-severity must be critical, warning, or info (got "${value}")`,
+  );
+}
+
+export function parseFailOnRules(value: string): string[] {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+/**
+ * Evaluate CI / Action policy against scan or verify results.
+ * Deterministic: same input → same violations in stable order.
+ */
+export function evaluatePolicy(input: PolicyInput, options: PolicyOptions): PolicyViolation[] {
+  const violations: PolicyViolation[] = [];
+
+  if (options.minimumScore !== undefined) {
+    if (input.agentSecurityAnalysis === "limited") {
+      violations.push({
+        code: "minimum-score",
+        message: `CI check failed: no supported coding-agent configuration detected; cannot enforce --min-score ${options.minimumScore}`,
+      });
+    } else if (input.scores === null) {
+      violations.push({
+        code: "minimum-score",
+        message: `CI check failed: readiness scores unavailable; cannot enforce --min-score ${options.minimumScore}`,
+      });
+    } else if (input.scores.overall < options.minimumScore) {
+      violations.push({
+        code: "minimum-score",
+        message: `CI check failed: overall score ${input.scores.overall} is below --min-score ${options.minimumScore}`,
+      });
+    }
+  }
+
+  if (options.failOnSeverity !== undefined) {
+    const threshold = severityRank(options.failOnSeverity);
+    const matched = input.findings.filter((f) => severityRank(f.severity) >= threshold);
+    if (matched.length > 0) {
+      const bySeverity = countBySeverity(matched);
+      violations.push({
+        code: "fail-on-severity",
+        message: `CI check failed: ${matched.length} finding(s) at or above ${options.failOnSeverity} (${formatSeverityCounts(bySeverity)})`,
+        details: [...new Set(matched.map((f) => f.ruleId))].sort(),
+      });
+    }
+  }
+
+  if (options.failOnRules && options.failOnRules.length > 0) {
+    const wanted = new Set(options.failOnRules);
+    const matched = input.findings.filter((f) => wanted.has(f.ruleId));
+    if (matched.length > 0) {
+      const rules = [...new Set(matched.map((f) => f.ruleId))].sort();
+      violations.push({
+        code: "fail-on-rule",
+        message: `CI check failed: ${matched.length} finding(s) match fail-on-rule (${rules.join(", ")})`,
+        details: rules,
+      });
+    }
+  }
+
+  if (options.failOnNew === true) {
+    const newCount = input.newFindingCount ?? 0;
+    if (newCount > 0) {
+      violations.push({
+        code: "fail-on-new",
+        message: `CI check failed: verify found ${newCount} new finding(s) not present in the baseline`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function evaluateScanPolicy(result: ScanResult, options: PolicyOptions): PolicyViolation[] {
+  const { failOnNew: _ignored, ...scanOptions } = options;
+  return evaluatePolicy(
+    {
+      findings: result.findings,
+      scores: result.scores,
+      agentSecurityAnalysis: result.agentSecurityAnalysis,
+    },
+    scanOptions,
+  );
+}
+
+export function evaluateVerifyPolicy(
+  result: {
+    findings?: Finding[];
+    after: ScanResult;
+    scores: Scores | null;
+    summary: { new: number };
+    newFindings?: Finding[];
+  },
+  options: PolicyOptions,
+): PolicyViolation[] {
+  const findings = result.after.findings;
+  return evaluatePolicy(
+    {
+      findings,
+      scores: result.scores,
+      newFindingCount: result.summary.new,
+      agentSecurityAnalysis: result.after.agentSecurityAnalysis,
+    },
+    options,
+  );
+}
+
+function countBySeverity(findings: Finding[]): Record<Severity, number> {
+  const counts: Record<Severity, number> = { critical: 0, warning: 0, info: 0 };
+  for (const finding of findings) {
+    counts[finding.severity] += 1;
+  }
+  return counts;
+}
+
+function formatSeverityCounts(counts: Record<Severity, number>): string {
+  const parts: string[] = [];
+  if (counts.critical > 0) {
+    parts.push(`${counts.critical} critical`);
+  }
+  if (counts.warning > 0) {
+    parts.push(`${counts.warning} warning`);
+  }
+  if (counts.info > 0) {
+    parts.push(`${counts.info} info`);
+  }
+  return parts.join(", ");
+}

--- a/src/core/rules/claude-deny.ts
+++ b/src/core/rules/claude-deny.ts
@@ -1,0 +1,52 @@
+import type { RuleContext } from "./types.js";
+
+/**
+ * Claude Code Read deny rule for a repository-relative path.
+ * Directories use a recursive Read(./path/**) form.
+ */
+export function claudeReadDenyRule(
+  relativePath: string,
+  kind: "file" | "directory" = "file",
+): string {
+  const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+  if (kind === "directory") {
+    return `Read(./${normalized}/**)`;
+  }
+  return `Read(./${normalized})`;
+}
+
+export function settingsTextDeniesPath(settingsText: string, relativePath: string): boolean {
+  const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+  const base = normalized.split("/").pop() ?? normalized;
+  const patterns = [
+    `Read(./${normalized})`,
+    `Read(${normalized})`,
+    `Read(./${normalized}/**)`,
+    `Read(./${normalized}/)`,
+    `Read(/**/${base})`,
+  ];
+  return patterns.some((p) => settingsText.includes(p));
+}
+
+export async function claudeDeniesPath(
+  context: RuleContext,
+  relativePath: string,
+): Promise<boolean> {
+  const settingsFiles =
+    context.agents
+      .find((a) => a.id === "claude-code")
+      ?.configFiles.filter(
+        (f) => f.kind === "claude-settings" || f.kind === "claude-settings-local",
+      ) ?? [];
+
+  for (const file of settingsFiles) {
+    const cached = await context.textCache.read(file.relativePath);
+    if (!cached.text) {
+      continue;
+    }
+    if (settingsTextDeniesPath(cached.text, relativePath)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/core/rules/codex-deny.ts
+++ b/src/core/rules/codex-deny.ts
@@ -1,0 +1,52 @@
+import type { RuleContext } from "./types.js";
+
+export function codexDenyKey(relativePath: string): string {
+  return relativePath.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+/** True when config.toml already denies this path (or path/**) under a filesystem table. */
+export function configTextDeniesPath(configText: string, relativePath: string): boolean {
+  const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+$/, "");
+  if (!normalized) {
+    return false;
+  }
+  const escaped = escapeRegExp(normalized);
+  const patterns = [
+    new RegExp(`^\\s*"${escaped}"\\s*=\\s*"deny"\\s*$`, "m"),
+    new RegExp(`^\\s*"${escaped}/\\*\\*"\\s*=\\s*"deny"\\s*$`, "m"),
+    new RegExp(`^\\s*'${escaped}'\\s*=\\s*'deny'\\s*$`, "m"),
+    new RegExp(`^\\s*'${escaped}/\\*\\*'\\s*=\\s*'deny'\\s*$`, "m"),
+  ];
+  return patterns.some((re) => re.test(configText));
+}
+
+export async function codexDeniesPath(
+  context: RuleContext,
+  relativePath: string,
+): Promise<boolean> {
+  const configFiles =
+    context.agents
+      .find((a) => a.id === "codex")
+      ?.configFiles.filter((f) => f.kind === "codex-config") ?? [];
+
+  for (const file of configFiles) {
+    const cached = await context.textCache.read(file.relativePath);
+    if (!cached.text) {
+      continue;
+    }
+    if (configTextDeniesPath(cached.text, relativePath)) {
+      return true;
+    }
+  }
+
+  // Config may exist but not yet be attached when only AGENTS.md detected; check path directly.
+  const direct = await context.textCache.read(".codex/config.toml");
+  if (direct.text && configTextDeniesPath(direct.text, relativePath)) {
+    return true;
+  }
+  return false;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/core/rules/context/generated-directory.ts
+++ b/src/core/rules/context/generated-directory.ts
@@ -1,5 +1,13 @@
-import { isSampleOrTestPath, isSourceNamedArtifactCollision } from "../path-kind.js";
-import type { FindingDraft, RuleDefinition } from "../types.js";
+import type { AgentId } from "../../../types/index.js";
+import { claudeDeniesPath } from "../claude-deny.js";
+import { codexDeniesPath } from "../codex-deny.js";
+import {
+  isCheckedInGithubActionDist,
+  isSampleOrTestPath,
+  isSourceNamedArtifactCollision,
+} from "../path-kind.js";
+import type { FindingDraft, RuleContext, RuleDefinition } from "../types.js";
+
 
 /** Directories commonly generated/build-related. vendor/ is ecosystem-aware. */
 const GENERATED = [
@@ -17,15 +25,36 @@ function isGeneratedPath(relativePath: string, name: string): boolean {
   return relativePath === name || relativePath.endsWith(`/${name}`);
 }
 
-function isExcluded(
-  context: Parameters<RuleDefinition["check"]>[0],
-  relativePath: string,
-): boolean {
-  const variants = [relativePath, `${relativePath}/`];
-  return variants.some(
-    (candidate) =>
-      context.ignore.matchesGitignore(candidate) || context.ignore.matchesCursorignore(candidate),
+function isGitIgnored(context: RuleContext, relativePath: string): boolean {
+  return (
+    context.ignore.matchesGitignore(relativePath) ||
+    context.ignore.matchesGitignore(`${relativePath}/`)
   );
+}
+
+async function agentsStillExposed(
+  context: RuleContext,
+  relativePath: string,
+  configured: AgentId[],
+): Promise<AgentId[]> {
+  const exposed: AgentId[] = [];
+  for (const agent of configured) {
+    if (
+      agent === "cursor" &&
+      (context.ignore.matchesCursorignore(relativePath) ||
+        context.ignore.matchesCursorignore(`${relativePath}/`))
+    ) {
+      continue;
+    }
+    if (agent === "claude-code" && (await claudeDeniesPath(context, relativePath))) {
+      continue;
+    }
+    if (agent === "codex" && (await codexDeniesPath(context, relativePath))) {
+      continue;
+    }
+    exposed.push(agent);
+  }
+  return exposed;
 }
 
 export const generatedDirectoryRule: RuleDefinition = {
@@ -41,8 +70,8 @@ export const generatedDirectoryRule: RuleDefinition = {
     "Ensure generated directories are listed in .gitignore and agent ignore configuration where applicable.",
   async check(context): Promise<FindingDraft[]> {
     const findings: FindingDraft[] = [];
-    const affected = context.agents.filter((a) => a.configured || a.detected).map((a) => a.id);
-    if (affected.length === 0) {
+    const configured = context.agents.filter((a) => a.configured || a.detected).map((a) => a.id);
+    if (configured.length === 0) {
       return [];
     }
 
@@ -57,7 +86,15 @@ export const generatedDirectoryRule: RuleDefinition = {
         if (isSourceNamedArtifactCollision(relativePath)) {
           continue;
         }
-        if (isExcluded(context, relativePath)) {
+        if (isCheckedInGithubActionDist(relativePath)) {
+          continue;
+        }
+        if (isGitIgnored(context, relativePath)) {
+          continue;
+        }
+
+        const affected = await agentsStillExposed(context, relativePath, configured);
+        if (affected.length === 0) {
           continue;
         }
 
@@ -69,7 +106,7 @@ export const generatedDirectoryRule: RuleDefinition = {
           message: `${relativePath}/ (${entry.label}) is present and no project ignore pattern was detected`,
           whyItMatters:
             "Generated directories are usually low-value for coding agents and can bloat indexing/context when not excluded.",
-          recommendation: `Add an ignore pattern covering ${relativePath}/ to .gitignore and, for Cursor, .cursorignore if you need agent-specific exclusion beyond gitignore.`,
+          recommendation: `Add an ignore pattern covering ${relativePath}/ to .gitignore and agent exclusions (.cursorignore, Claude Code Read deny, and/or Codex filesystem deny).`,
           affectedAgents: affected,
           evidence: { path: relativePath },
           fixability: "safe",
@@ -90,7 +127,14 @@ export const generatedDirectoryRule: RuleDefinition = {
         if (isSampleOrTestPath(relativePath)) {
           continue;
         }
-        if (isExcluded(context, relativePath)) {
+        if (isSourceNamedArtifactCollision(relativePath)) {
+          continue;
+        }
+        if (isGitIgnored(context, relativePath)) {
+          continue;
+        }
+        const affected = await agentsStillExposed(context, relativePath, configured);
+        if (affected.length === 0) {
           continue;
         }
         findings.push({

--- a/src/core/rules/context/large-log-file.ts
+++ b/src/core/rules/context/large-log-file.ts
@@ -1,8 +1,9 @@
+import { isLogLikePath } from "../../../discovery/log-like.js";
+import type { AgentId } from "../../../types/index.js";
+import { claudeDeniesPath } from "../claude-deny.js";
+import { codexDeniesPath } from "../codex-deny.js";
 import { THRESHOLDS } from "../thresholds.js";
 import type { FindingDraft, RuleDefinition } from "../types.js";
-
-const LOG_LIKE = /\.(log|out|dump)$/i;
-const HEAVY_NAME = /(^|\/)(debug|trace|coverage-final|chrome-devtools|heapdump)/i;
 
 export const largeLogFileRule: RuleDefinition = {
   id: "context/large-log-file",
@@ -15,23 +16,38 @@ export const largeLogFileRule: RuleDefinition = {
   recommendation: "Delete or ignore large logs; add them to .gitignore and agent ignore files.",
   async check(context): Promise<FindingDraft[]> {
     const findings: FindingDraft[] = [];
-    const affected = context.agents.filter((a) => a.configured || a.detected).map((a) => a.id);
+    const configured = context.agents
+      .filter((a) => a.configured || a.detected)
+      .map((a) => a.id as AgentId);
 
     for (const file of context.discovery.files) {
-      const base = file.relativePath.split("/").pop() ?? file.relativePath;
-      const looksLog = LOG_LIKE.test(base) || HEAVY_NAME.test(file.relativePath);
-      if (!looksLog) {
+      if (!isLogLikePath(file.relativePath)) {
         continue;
       }
       if (file.sizeBytes < THRESHOLDS.largeLogBytes) {
         continue;
       }
 
-      // Skip if clearly ignored for Cursor and no other agents configured
-      if (
-        context.ignore.matchesGitignore(file.relativePath) ||
-        context.ignore.matchesCursorignore(file.relativePath)
-      ) {
+      if (context.ignore.matchesGitignore(file.relativePath)) {
+        continue;
+      }
+
+      const defaultAgents: AgentId[] = ["cursor", "claude-code", "codex"];
+      const candidates = configured.length > 0 ? configured : defaultAgents;
+      const affected: AgentId[] = [];
+      for (const agent of candidates) {
+        if (agent === "cursor" && context.ignore.matchesCursorignore(file.relativePath)) {
+          continue;
+        }
+        if (agent === "claude-code" && (await claudeDeniesPath(context, file.relativePath))) {
+          continue;
+        }
+        if (agent === "codex" && (await codexDeniesPath(context, file.relativePath))) {
+          continue;
+        }
+        affected.push(agent);
+      }
+      if (affected.length === 0) {
         continue;
       }
 
@@ -44,7 +60,7 @@ export const largeLogFileRule: RuleDefinition = {
         whyItMatters:
           "Large logs and dumps rarely help coding agents and can crowd out useful source context.",
         recommendation: "Remove or ignore this file for both git and AI agent tooling.",
-        affectedAgents: affected.length > 0 ? affected : ["cursor", "claude-code", "codex"],
+        affectedAgents: affected,
         evidence: { path: file.relativePath, detail: `${file.sizeBytes} bytes` },
         fixability: "safe",
       });

--- a/src/core/rules/instructions/missing-path-reference.ts
+++ b/src/core/rules/instructions/missing-path-reference.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
 import { pathExistsInsideRoot } from "../../../agents/inspect.js";
+import { preparePathReference } from "../../path-resolution/index.js";
 import { isPathInsideRoot } from "../../../utils/path.js";
 import type { FindingDraft, RuleDefinition } from "../types.js";
 
@@ -253,7 +254,15 @@ export const missingPathReferenceRule: RuleDefinition = {
 
         const candidates = extractPathCandidates(cached.text);
         for (const candidate of candidates) {
-          const resolved = resolveInstructionPathReference(file.relativePath, candidate);
+          const prepared = preparePathReference(candidate);
+          if (prepared.status === "reject") {
+            continue;
+          }
+
+          const resolved = resolveInstructionPathReference(
+            file.relativePath,
+            prepared.normalized,
+          );
 
           if (resolved.status === "escape") {
             findings.push({
@@ -261,14 +270,14 @@ export const missingPathReferenceRule: RuleDefinition = {
               category: "instructions",
               severity: "warning",
               title: "Instruction references a missing path",
-              message: `${file.relativePath} references \`${candidate}\`, which escapes the repository root`,
+              message: `${file.relativePath} references \`${prepared.original}\`, which escapes the repository root`,
               whyItMatters:
                 "Path references outside the repository cannot be validated and may confuse agents.",
               recommendation: "Use repository-relative paths only.",
               affectedAgents: context.agents
                 .filter((a) => a.configPaths.includes(file.relativePath))
                 .map((a) => a.id),
-              evidence: { path: file.relativePath, detail: `ref=${candidate}` },
+              evidence: { path: file.relativePath, detail: `ref=${prepared.original}` },
               fixability: "manual",
             });
             continue;
@@ -295,7 +304,7 @@ export const missingPathReferenceRule: RuleDefinition = {
             category: "instructions",
             severity: "warning",
             title: "Instruction references a missing path",
-            message: `${file.relativePath} references \`${candidate}\`, but that path does not exist`,
+            message: `${file.relativePath} references \`${prepared.original}\`, but that path does not exist`,
             whyItMatters:
               "Agents may follow documented paths that no longer exist, causing failed reads and wasted context.",
             recommendation: "Fix the path or remove the stale reference.",

--- a/src/core/rules/path-kind.ts
+++ b/src/core/rules/path-kind.ts
@@ -18,19 +18,64 @@ const SAMPLE_DIRECTORY_NAMES = new Set([
   "samples",
   "test",
   "tests",
+  "testing",
   "__tests__",
   "testdata",
   "test_data",
+  "spec",
+  "specs",
+  "demo",
+  "demos",
+  "e2e",
+  "bench",
+  "benchmark",
+  "benchmarks",
+  "playground",
+  "playgrounds",
+  "sandbox",
+  "sandboxes",
 ]);
 
-/** Artifact dir names that commonly collide with source packages (`scripts/build`, `internal/build`). */
-const ARTIFACT_NAMES_WITH_SOURCE_COLLISIONS = new Set(["build", "target"]);
+/** Strong tokens that mark intentional non-production material when present in a segment. */
+const STRONG_TEST_TOKENS = new Set([
+  "test",
+  "tests",
+  "testing",
+  "fixture",
+  "fixtures",
+  "mock",
+  "mocks",
+  "testdata",
+  "spec",
+  "specs",
+  "e2e",
+  "bench",
+  "benchmark",
+  "benchmarks",
+  "playground",
+  "playgrounds",
+  "sandbox",
+  "sandboxes",
+  "example",
+  "examples",
+  "sample",
+  "samples",
+  "demo",
+  "demos",
+]);
 
 /**
- * Parent dirs that host source code packages/modules, not generated output trees.
- * `packages/foo/dist` is still treated as generated (parent is the package name).
+ * Artifact dir names that commonly collide with source packages
+ * (scripts/build, packages/foo/src/core/build, src/.../vendor).
+ * Intentionally excludes dist — paths like src/js/dist are often real build output.
  */
-const SOURCE_CODE_PARENT_DIRS = new Set([
+const ARTIFACT_NAMES_WITH_SOURCE_COLLISIONS = new Set(["build", "target", "vendor"]);
+
+/**
+ * Dir names that host source code packages/modules, not generated output trees.
+ * packages/foo/dist is still treated as generated (no source-marker ancestor).
+ */
+const SOURCE_CODE_MARKER_DIRS = new Set([
   "bin",
   "cmd",
   "internal",
@@ -41,9 +86,56 @@ const SOURCE_CODE_PARENT_DIRS = new Set([
   "src",
 ]);
 
+function splitCamelCase(segment: string): string[] {
+  return segment
+    .replace(/([a-z0-9])([A-Z])/g, "$1\0$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1\0$2")
+    .split("\0")
+    .filter(Boolean);
+}
+
+/**
+ * True when a single path segment denotes sample/test/fixture material.
+ * Handles exact names, leading-underscore variants, hyphen/underscore compounds,
+ * and camelCase forms (dockerTest, testFixtures) without matching production roots.
+ */
+export function isSampleOrTestSegment(segment: string): boolean {
+  if (!segment) {
+    return false;
+  }
+
+  const lower = segment.toLowerCase();
+  if (SAMPLE_DIRECTORY_NAMES.has(lower)) {
+    return true;
+  }
+
+  // _fixture, _fixtures, _testdata, __fixture
+  const stripped = lower.replace(/^_+/, "");
+  if (stripped !== lower && SAMPLE_DIRECTORY_NAMES.has(stripped)) {
+    return true;
+  }
+
+  // integration-test, smoke-test, docker-test, integration_tests, test-certs
+  const hyphenTokens = lower.split(/[-_]+/).filter(Boolean);
+  if (hyphenTokens.length >= 2 && hyphenTokens.some((token) => STRONG_TEST_TOKENS.has(token))) {
+    return true;
+  }
+
+  // dockerTest, testFixtures, httpTestServer, integrationTests
+  if (/[A-Z]/.test(segment)) {
+    const camelTokens = splitCamelCase(segment).map((part) => part.toLowerCase());
+    if (camelTokens.some((token) => STRONG_TEST_TOKENS.has(token))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * True when any path segment marks fixture, test, example, or sample material.
  * Uses POSIX relative paths (discovery output).
+ * Filenames never qualify alone (root `test-private-key.pem` must still flag).
  */
 export function isSampleOrTestPath(relativePath: string): boolean {
   if (!relativePath) {
@@ -53,12 +145,21 @@ export function isSampleOrTestPath(relativePath: string): boolean {
   if (!normalized) {
     return false;
   }
-  return normalized.split("/").some((segment) => SAMPLE_DIRECTORY_NAMES.has(segment.toLowerCase()));
+  const parts = normalized.split("/").filter(Boolean);
+  return parts.some((segment, index) => {
+    const isLast = index === parts.length - 1;
+    const looksLikeFile = isLast && /\.[A-Za-z0-9_+-]+$/.test(segment);
+    if (looksLikeFile) {
+      return false;
+    }
+    return isSampleOrTestSegment(segment);
+  });
 }
 
 /**
- * True for paths like `scripts/build` or `internal/build` that are source trees
- * named after a common artifact directory, not generated output.
+ * True for paths like `scripts/build`, `internal/build`, or `packages/foo/src/core/build`
+ * that are source trees named after a common artifact directory, not generated output.
+ * Any source-marker ancestor qualifies (not only the immediate parent).
  */
 export function isSourceNamedArtifactCollision(relativePath: string): boolean {
   if (!relativePath) {
@@ -77,6 +178,20 @@ export function isSourceNamedArtifactCollision(relativePath: string): boolean {
   if (!ARTIFACT_NAMES_WITH_SOURCE_COLLISIONS.has(leaf)) {
     return false;
   }
-  const parent = parts[parts.length - 2]!.toLowerCase();
-  return SOURCE_CODE_PARENT_DIRS.has(parent);
+  return parts.slice(0, -1).some((segment) => SOURCE_CODE_MARKER_DIRS.has(segment.toLowerCase()));
+}
+
+/**
+ * True for checked-in GitHub Action package output (`.github/actions/<name>/dist`).
+ * These are intentional publish artifacts, not ambient generated junk.
+ */
+export function isCheckedInGithubActionDist(relativePath: string): boolean {
+  if (!relativePath) {
+    return false;
+  }
+  const normalized = relativePath
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/\/+$/, "");
+  return /^\.github\/actions\/[^/]+\/dist$/i.test(normalized);
 }

--- a/src/core/rules/security/env-file-exposure.ts
+++ b/src/core/rules/security/env-file-exposure.ts
@@ -1,4 +1,6 @@
 import type { AgentId } from "../../../types/index.js";
+import { claudeDeniesPath } from "../claude-deny.js";
+import { codexDeniesPath } from "../codex-deny.js";
 import { isSampleOrTestPath } from "../path-kind.js";
 import type { FindingDraft, RuleContext, RuleDefinition } from "../types.js";
 
@@ -78,32 +80,6 @@ function agentsWithoutClearExclusion(context: RuleContext, relativePath: string)
   return affected;
 }
 
-async function claudeDeniesRead(context: RuleContext, relativePath: string): Promise<boolean> {
-  const settingsFiles =
-    context.agents
-      .find((a) => a.id === "claude-code")
-      ?.configFiles.filter(
-        (f) => f.kind === "claude-settings" || f.kind === "claude-settings-local",
-      ) ?? [];
-
-  for (const file of settingsFiles) {
-    const cached = await context.textCache.read(file.relativePath);
-    if (!cached.text) continue;
-    const patterns = [
-      `Read(./${relativePath})`,
-      `Read(${relativePath})`,
-      `Read(/**/${relativePath.split("/").pop()})`,
-    ];
-    if (patterns.some((p) => cached.text!.includes(p))) {
-      return true;
-    }
-    if (/"deny"\s*:\s*\[[^\]]*"Read"\s*[,\]]/.test(cached.text)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export const envFileExposureRule: RuleDefinition = {
   id: "security/env-file-exposure",
   title: "Sensitive environment file may enter agent context",
@@ -157,8 +133,14 @@ export const envFileExposureRule: RuleDefinition = {
       let affected = agentsWithoutClearExclusion(context, file.relativePath);
 
       if (affected.includes("claude-code")) {
-        if (await claudeDeniesRead(context, file.relativePath)) {
+        if (await claudeDeniesPath(context, file.relativePath)) {
           affected = affected.filter((a) => a !== "claude-code");
+        }
+      }
+
+      if (affected.includes("codex")) {
+        if (await codexDeniesPath(context, file.relativePath)) {
+          affected = affected.filter((a) => a !== "codex");
         }
       }
 
@@ -175,7 +157,7 @@ export const envFileExposureRule: RuleDefinition = {
         whyItMatters:
           "Environment files frequently hold API keys and credentials. If readable by an AI coding agent, those values may be included in prompts or logs.",
         recommendation:
-          "Add an agent-specific exclusion (for example .cursorignore or a Claude Code Read deny rule), keep the file out of version control, and rotate any credentials that may have been exposed.",
+          "Add an agent-specific exclusion (for example .cursorignore, a Claude Code Read deny rule, or a Codex filesystem deny), keep the file out of version control, and rotate any credentials that may have been exposed.",
         affectedAgents: affected,
         evidence: {
           path: file.relativePath,

--- a/src/discovery/files.ts
+++ b/src/discovery/files.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { DEFAULT_IGNORE_DIRECTORIES, DEFAULT_MAX_FILE_SIZE_BYTES } from "../constants.js";
 import type { DiscoveredFile, DiscoveryResult } from "../types/index.js";
 import { isPathInsideRoot, toPosixRelative } from "../utils/path.js";
+import { isLogLikePath } from "./log-like.js";
 
 export interface DiscoverFilesOptions {
   root: string;
@@ -89,14 +90,18 @@ export async function discoverFiles(options: DiscoverFilesOptions): Promise<Disc
 
       try {
         const stat = await fs.lstat(absolutePath);
-        if (stat.size > maxFileSizeBytes) {
+        const sizeBytes = Number(stat.size);
+        // Oversized binaries stay skipped (content reads already refuse them).
+        // Log/dump-like paths are kept as metadata so context/large-log-file
+        // can flag the worst offenders instead of silently missing them.
+        if (sizeBytes > maxFileSizeBytes && !isLogLikePath(relativePath)) {
           filesSkippedOversized += 1;
           continue;
         }
         files.push({
           absolutePath,
           relativePath,
-          sizeBytes: Number(stat.size),
+          sizeBytes,
           isSymlink,
         });
       } catch (error) {

--- a/src/discovery/log-like.ts
+++ b/src/discovery/log-like.ts
@@ -1,0 +1,8 @@
+const LOG_LIKE = /\.(log|out|dump)$/i;
+const HEAVY_NAME = /(^|\/)(debug|trace|coverage-final|chrome-devtools|heapdump)/i;
+
+/** Path looks like a log/dump that can pollute agent context (size-only rules). */
+export function isLogLikePath(relativePath: string): boolean {
+  const base = relativePath.split("/").pop() ?? relativePath;
+  return LOG_LIKE.test(base) || HEAVY_NAME.test(relativePath);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,4 +25,17 @@ export { runRules } from "./core/rules/run-rules.js";
 export { buildFixPlan } from "./core/fix/plan.js";
 export { applyFixPlan } from "./core/fix/apply.js";
 export { runFix } from "./core/fix/run.js";
+export {
+  evaluatePolicy,
+  evaluateScanPolicy,
+  evaluateVerifyPolicy,
+  parseFailOnRules,
+  parseSeverityGate,
+} from "./core/policy/evaluate.js";
+export type {
+  PolicyOptions,
+  PolicyViolation,
+  PolicyViolationCode,
+  PolicyInput,
+} from "./core/policy/evaluate.js";
 export type { FixPlan, FixAction, FixApplyResult } from "./core/fix/types.js";

--- a/src/reporters/github/annotations.ts
+++ b/src/reporters/github/annotations.ts
@@ -1,0 +1,49 @@
+import type { Finding, Severity } from "../../types/index.js";
+
+/**
+ * GitHub Actions workflow commands for file annotations.
+ * Emitted to stderr so `--json` stdout stays pure JSON.
+ *
+ * @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+ */
+export function renderGithubAnnotations(findings: Finding[]): string {
+  const lines: string[] = [];
+  for (const finding of findings) {
+    lines.push(formatAnnotation(finding));
+  }
+  return lines.length > 0 ? `${lines.join("\n")}\n` : "";
+}
+
+function formatAnnotation(finding: Finding): string {
+  const level = annotationLevel(finding.severity);
+  const properties: string[] = [];
+  const file = finding.evidence?.path?.replace(/\\/g, "/");
+  if (file) {
+    properties.push(`file=${escapeProperty(file)}`);
+  }
+  if (finding.evidence?.line !== undefined && Number.isFinite(finding.evidence.line)) {
+    properties.push(`line=${finding.evidence.line}`);
+  }
+  properties.push(`title=${escapeProperty(`${finding.ruleId}: ${finding.title}`)}`);
+
+  const message = escapeMessage(`${finding.message} (${finding.ruleId})`);
+  const props = properties.length > 0 ? ` ${properties.join(",")}` : "";
+  return `::${level}${props}::${message}`;
+}
+
+function annotationLevel(severity: Severity): "error" | "warning" | "notice" {
+  return severity === "critical" ? "error" : severity === "warning" ? "warning" : "notice";
+}
+
+function escapeProperty(value: string): string {
+  return value
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+    .replace(/:/g, "%3A")
+    .replace(/,/g, "%2C");
+}
+
+function escapeMessage(value: string): string {
+  return value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}

--- a/src/reporters/github/emit.ts
+++ b/src/reporters/github/emit.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+
+import type { PolicyViolation } from "../../core/policy/evaluate.js";
+import type { Finding } from "../../types/index.js";
+import { renderGithubAnnotations } from "./annotations.js";
+import { renderGithubStepSummary } from "./summary.js";
+
+export interface GithubReportOptions {
+  summary?: boolean;
+  annotations?: boolean;
+}
+
+export async function emitGithubReports(options: {
+  mode: "scan" | "verify";
+  findings: Finding[];
+  overallScore: number | null;
+  violations: PolicyViolation[];
+  verifySummary?: { fixed: number; remaining: number; new: number; unchanged: number };
+  summary?: boolean;
+  annotations?: boolean;
+  /** Override for tests */
+  stepSummaryPath?: string | null;
+  annotationsWrite?: (text: string) => void;
+}): Promise<void> {
+  if (options.annotations) {
+    const text = renderGithubAnnotations(options.findings);
+    if (text.length > 0) {
+      const write = options.annotationsWrite ?? ((chunk: string) => process.stderr.write(chunk));
+      write(text);
+    }
+  }
+
+  if (!options.summary) {
+    return;
+  }
+
+  const markdown = renderGithubStepSummary({
+    title: options.mode === "verify" ? "AgentDoctor Verify" : "AgentDoctor Scan",
+    overallScore: options.overallScore,
+    findings: options.findings,
+    violations: options.violations,
+    mode: options.mode,
+    ...(options.verifySummary ? { verifySummary: options.verifySummary } : {}),
+  });
+  const summaryPath =
+    options.stepSummaryPath !== undefined
+      ? options.stepSummaryPath
+      : (process.env.GITHUB_STEP_SUMMARY ?? null);
+  if (summaryPath) {
+    await fs.appendFile(summaryPath, markdown, "utf8");
+    return;
+  }
+  process.stderr.write(
+    "Note: --summary set but GITHUB_STEP_SUMMARY is unset; skipping step summary write.\n",
+  );
+}

--- a/src/reporters/github/summary.ts
+++ b/src/reporters/github/summary.ts
@@ -1,0 +1,145 @@
+import type { Finding, ScanResult, Severity } from "../../types/index.js";
+import type { PolicyViolation } from "../../core/policy/evaluate.js";
+
+export interface GithubSummaryInput {
+  title: string;
+  overallScore: number | null;
+  findings: Finding[];
+  violations: PolicyViolation[];
+  mode: "scan" | "verify";
+  verifySummary?: { fixed: number; remaining: number; new: number; unchanged: number };
+}
+
+/**
+ * Markdown for `$GITHUB_STEP_SUMMARY`.
+ */
+export function renderGithubStepSummary(input: GithubSummaryInput): string {
+  const lines: string[] = [];
+  lines.push(`# AgentDoctor ${input.mode === "verify" ? "Verify" : "Scan"}`);
+  lines.push("");
+
+  if (input.overallScore !== null) {
+    lines.push(`**Readiness:** ${input.overallScore}/100`);
+    lines.push("");
+  }
+
+  if (input.violations.length > 0) {
+    lines.push("## Policy violations");
+    lines.push("");
+    for (const violation of input.violations) {
+      lines.push(`- ${violation.message}`);
+    }
+    lines.push("");
+  } else {
+    lines.push("Policy gates: **passed**");
+    lines.push("");
+  }
+
+  if (input.verifySummary) {
+    lines.push("## Verify delta");
+    lines.push("");
+    lines.push(`| Fixed | Remaining | New | Unchanged |`);
+    lines.push(`| ---: | ---: | ---: | ---: |`);
+    lines.push(
+      `| ${input.verifySummary.fixed} | ${input.verifySummary.remaining} | ${input.verifySummary.new} | ${input.verifySummary.unchanged} |`,
+    );
+    lines.push("");
+  }
+
+  const critical = input.findings.filter((f) => f.severity === "critical").length;
+  const warning = input.findings.filter((f) => f.severity === "warning").length;
+  const info = input.findings.filter((f) => f.severity === "info").length;
+
+  lines.push("## Findings");
+  lines.push("");
+  lines.push(`| Severity | Count |`);
+  lines.push(`| --- | ---: |`);
+  lines.push(`| Critical | ${critical} |`);
+  lines.push(`| Warning | ${warning} |`);
+  lines.push(`| Info | ${info} |`);
+  lines.push(`| **Total** | **${input.findings.length}** |`);
+  lines.push("");
+
+  if (input.findings.length > 0) {
+    lines.push("### Top findings");
+    lines.push("");
+    const top = [...input.findings]
+      .sort((a, b) => severityOrder(b.severity) - severityOrder(a.severity))
+      .slice(0, 20);
+    for (const finding of top) {
+      const path = finding.evidence?.path ? ` \`${finding.evidence.path}\`` : "";
+      lines.push(`- **${finding.severity}** \`${finding.ruleId}\`${path} — ${finding.title}`);
+    }
+    lines.push("");
+  }
+
+  if (input.violations.length > 0) {
+    lines.push(...renderGithubNextSteps(input));
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Shortest path back to green when the Action failed a policy gate.
+ * Shown only on failure — success summaries stay quiet.
+ */
+function renderGithubNextSteps(input: GithubSummaryInput): string[] {
+  const lines: string[] = [];
+  lines.push("## Next");
+  lines.push("");
+  lines.push("Policy gate failed. Shortest path back to green:");
+  lines.push("");
+
+  const hasSafe = input.findings.some((f) => f.fixability === "safe");
+  const topRule = [...input.findings]
+    .sort((a, b) => severityOrder(b.severity) - severityOrder(a.severity))[0]?.ruleId;
+
+  if (input.mode === "verify") {
+    lines.push("1. Reproduce locally: `npx @praneeth_54/agentdoctor verify`");
+    if (hasSafe) {
+      lines.push("2. Apply safe fixes: `npx @praneeth_54/agentdoctor fix -y`");
+      lines.push("3. Re-check: `npx @praneeth_54/agentdoctor verify`");
+    } else {
+      lines.push(
+        `2. Inspect a finding: \`npx @praneeth_54/agentdoctor explain ${topRule ?? "<rule-id>"}\``,
+      );
+      lines.push("3. Fix or baseline, then re-run this Action");
+    }
+  } else {
+    lines.push("1. Reproduce locally: `npx @praneeth_54/agentdoctor scan --ci`");
+    if (hasSafe) {
+      lines.push("2. Apply safe fixes: `npx @praneeth_54/agentdoctor fix -y`");
+      lines.push("3. Confirm: `npx @praneeth_54/agentdoctor scan --ci`");
+    } else {
+      lines.push(
+        `2. Inspect a finding: \`npx @praneeth_54/agentdoctor explain ${topRule ?? "<rule-id>"}\``,
+      );
+      lines.push("3. Fix the gated findings, then re-run this Action");
+    }
+  }
+
+  lines.push("");
+  lines.push(
+    "Preview before applying: `npx @praneeth_54/agentdoctor fix --dry-run`",
+  );
+  lines.push("");
+  return lines;
+}
+
+export function renderGithubStepSummaryForScan(
+  result: ScanResult,
+  violations: PolicyViolation[],
+): string {
+  return renderGithubStepSummary({
+    title: "AgentDoctor Scan",
+    overallScore: result.scores?.overall ?? null,
+    findings: result.findings,
+    violations,
+    mode: "scan",
+  });
+}
+
+function severityOrder(severity: Severity): number {
+  return severity === "critical" ? 3 : severity === "warning" ? 2 : 1;
+}

--- a/src/reporters/terminal/report.ts
+++ b/src/reporters/terminal/report.ts
@@ -57,7 +57,14 @@ function renderFindingBlock(finding: Finding, verbose: boolean): string[] {
         ? symbolWarn()
         : symbolInfo();
 
-  lines.push(`  ${icon} ${sanitizeTerminalText(finding.title)}`);
+  const fixTag =
+    finding.fixability === "safe"
+      ? colors.green("[safe]")
+      : finding.fixability === "review"
+        ? colors.yellow("[review]")
+        : colors.dim("[manual]");
+
+  lines.push(`  ${icon} ${fixTag} ${sanitizeTerminalText(finding.title)}`);
   if (finding.evidence?.path) {
     lines.push(colors.dim(`    ${sanitizeTerminalText(finding.evidence.path)}`));
   }
@@ -71,6 +78,63 @@ function renderFindingBlock(finding: Finding, verbose: boolean): string[] {
   if (finding.recommendation) {
     lines.push(`    Fix: ${sanitizeTerminalText(finding.recommendation)}`);
   }
+  lines.push("");
+  return lines;
+}
+
+function countByFixability(findings: Finding[]): { safe: number; review: number; manual: number } {
+  let safe = 0;
+  let review = 0;
+  let manual = 0;
+  for (const finding of findings) {
+    if (finding.fixability === "safe") {
+      safe += 1;
+    } else if (finding.fixability === "review") {
+      review += 1;
+    } else {
+      manual += 1;
+    }
+  }
+  return { safe, review, manual };
+}
+
+/**
+ * Close the Scan → Fix → Verify loop on first run.
+ * Empty / agentless scans already print a Next line; findings used to dead-end.
+ */
+export function renderNextSteps(result: ScanResult): string[] {
+  const lines: string[] = [];
+  const total = result.summary.total;
+  if (total === 0) {
+    return lines;
+  }
+
+  const { safe, review, manual } = countByFixability(result.findings);
+  const reviewLike = review + manual;
+
+  lines.push(colors.bold("Next"));
+  lines.push("");
+  if (safe > 0) {
+    lines.push(
+      `  ${safe} finding(s) are auto-fixable. Preview: ${colors.bold("agentdoctor fix --dry-run")}`,
+    );
+    lines.push(`  Apply: ${colors.bold("agentdoctor fix -y")}`);
+  } else if (reviewLike > 0) {
+    lines.push(
+      `  ${reviewLike} finding(s) need review or manual action — ${colors.bold("agentdoctor fix")} will not change them automatically.`,
+    );
+    lines.push(
+      colors.dim("  Inspect a rule: agentdoctor explain <rule-id>  (ids are in --json output)"),
+    );
+  }
+  lines.push(
+    colors.dim(
+      "  Save a verify baseline: agentdoctor scan --json > agentdoctor-report.json",
+    ),
+  );
+  lines.push(
+    colors.dim("  After changes: agentdoctor verify --baseline agentdoctor-report.json"),
+  );
   lines.push("");
   return lines;
 }
@@ -153,7 +217,14 @@ export function renderTerminalReport(
 
   if (total === 0) {
     if (limited) {
-      lines.push(`  ${symbolOk()} No agent-configuration findings`);
+      lines.push(`  ${symbolWarn()} Nothing to audit yet — no Cursor, Claude Code, or Codex config found`);
+      lines.push("");
+      lines.push(
+        colors.dim(
+          "  Next: add project agent config (for example `.cursor/`, `CLAUDE.md` / `.claude/`, or `AGENTS.md`),",
+        ),
+      );
+      lines.push(colors.dim("  then re-run `agentdoctor` in this repository."));
     } else {
       lines.push(`  ${symbolOk()} No findings`);
     }
@@ -190,7 +261,7 @@ export function renderTerminalReport(
     if (total > shown) {
       lines.push(
         colors.dim(
-          `  … and ${total - shown} more. Re-run with --verbose to see additional detail.`,
+          `  … and ${total - shown} more. Re-run with --verbose for detail, or --json for the full list.`,
         ),
       );
       lines.push("");
@@ -202,14 +273,35 @@ export function renderTerminalReport(
   lines.push(`  ${result.summary.critical} critical`);
   lines.push(`  ${result.summary.warning} warning`);
   lines.push(`  ${result.summary.info} info`);
+  if (total > 0) {
+    const { safe, review, manual } = countByFixability(result.findings);
+    lines.push(
+      colors.dim(
+        `  Fixability: ${safe} safe · ${review} review · ${manual} manual`,
+      ),
+    );
+  }
   lines.push("");
   if (result.scoringAvailable && result.scores) {
-    lines.push(`  Readiness: ${result.scores.overall}/100`);
-    lines.push(colors.dim("  Category and agent scores: agentdoctor scan --json"));
+    if (limited) {
+      lines.push(
+        `  Readiness: n/a — configure Cursor, Claude Code, or Codex before treating scores as agent readiness`,
+      );
+      lines.push(
+        colors.dim(
+          `  Numeric scores remain in JSON (overall ${result.scores.overall}/100) for repository-risk findings only`,
+        ),
+      );
+    } else {
+      lines.push(`  Readiness: ${result.scores.overall}/100`);
+      lines.push(colors.dim("  Category and agent scores: agentdoctor scan --json"));
+    }
   } else {
     lines.push(colors.dim("  Readiness scoring unavailable for this scan"));
   }
   lines.push("");
+
+  lines.push(...renderNextSteps(result));
 
   if (verbose) {
     lines.push(colors.dim("Timing"));

--- a/src/reporters/verify/terminal.ts
+++ b/src/reporters/verify/terminal.ts
@@ -62,5 +62,46 @@ export function renderVerifyTerminalReport(result: VerifyResult, verbose = false
     );
   }
   lines.push("");
+  lines.push(...renderVerifyNextSteps(result));
   return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Close the verify step: tell a first-time user what to do with Fixed / Remaining / New.
+ */
+export function renderVerifyNextSteps(result: VerifyResult): string[] {
+  const lines: string[] = [];
+  const { fixed, remaining, new: newly } = result.summary;
+
+  lines.push(colors.bold("Next"));
+  if (remaining === 0 && newly === 0) {
+    lines.push(
+      fixed > 0
+        ? "  All tracked findings cleared. Optional: gate CI with agentdoctor scan --ci"
+        : "  No regressions vs baseline. Optional: gate CI with agentdoctor scan --ci",
+    );
+  } else {
+    if (newly > 0) {
+      lines.push(
+        `  ${newly} new finding(s) appeared since the baseline — inspect: agentdoctor scan`,
+      );
+    }
+    if (remaining > 0) {
+      lines.push(
+        `  ${remaining} finding(s) still open — auto-fixable ones: agentdoctor fix --dry-run`,
+      );
+      lines.push(
+        colors.dim(
+          "  Review/manual leftovers: agentdoctor explain <rule-id>  (ids in scan --json)",
+        ),
+      );
+    }
+    lines.push(
+      colors.dim(
+        "  After more fixes, re-check: agentdoctor verify --baseline agentdoctor-report.json",
+      ),
+    );
+  }
+  lines.push("");
+  return lines;
 }

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -13,6 +13,7 @@ import { EXIT_CODES } from "../../src/types/index.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const cleanProject = path.resolve(here, "../../fixtures/clean-project");
+const cleanConfigured = path.resolve(here, "../../fixtures/clean-configured-project");
 const multiAgent = path.resolve(here, "../../fixtures/multi-agent-project");
 const insecureProject = path.resolve(here, "../../fixtures/insecure-agent-project");
 
@@ -39,8 +40,8 @@ async function parseCli(argv: string[]): Promise<{ output: string; exitCode: num
   process.exitCode = undefined;
   try {
     const output = await captureStdout(async () => {
-      const program = createProgram();
-      await program.parseAsync(["node", "agentdoctor", ...argv]);
+      const { runCli } = await import("../../src/cli/program.js");
+      await runCli(["node", "agentdoctor", ...argv]);
     });
     return { output, exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
   } finally {
@@ -74,14 +75,25 @@ describe("CLI program", () => {
     });
   });
 
-  it("clean repo with --min-score 99 succeeds", async () => {
+  it("clean configured repo with --min-score 99 succeeds", async () => {
     await silenceStdout(async () => {
       const code = await runScanCommand({
-        targetPath: cleanProject,
+        targetPath: cleanConfigured,
         json: true,
         minScore: 99,
       });
       expect(code).toBe(EXIT_CODES.SUCCESS);
+    });
+  });
+
+  it("agentless repo with --min-score fails instead of vacuous 100", async () => {
+    await silenceStdout(async () => {
+      const code = await runScanCommand({
+        targetPath: cleanProject,
+        json: true,
+        minScore: 70,
+      });
+      expect(code).toBe(EXIT_CODES.ISSUES_OR_THRESHOLD);
     });
   });
 
@@ -96,10 +108,21 @@ describe("CLI program", () => {
     });
   });
 
-  it("--ci alone remains report-only (exit 0)", async () => {
+  it("--ci alone fails on critical findings", async () => {
     await silenceStdout(async () => {
       const code = await runScanCommand({
         targetPath: insecureProject,
+        json: true,
+        ci: true,
+      });
+      expect(code).toBe(EXIT_CODES.ISSUES_OR_THRESHOLD);
+    });
+  });
+
+  it("--ci alone succeeds when no critical findings", async () => {
+    await silenceStdout(async () => {
+      const code = await runScanCommand({
+        targetPath: cleanConfigured,
         json: true,
         ci: true,
       });
@@ -107,7 +130,7 @@ describe("CLI program", () => {
     });
   });
 
-  it("no threshold exits 0 even when findings exist", async () => {
+  it("scan without --ci stays report-only even with critical findings", async () => {
     await silenceStdout(async () => {
       const code = await runScanCommand({
         targetPath: insecureProject,
@@ -183,6 +206,66 @@ describe("CLI program", () => {
     expectJsonScanReport(output);
   });
 
+  it("argv: --fail-on-severity critical fails on insecure fixture", async () => {
+    const { output, exitCode } = await parseCli([
+      "scan",
+      insecureProject,
+      "--json",
+      "--fail-on-severity",
+      "critical",
+    ]);
+    expect(exitCode).toBe(EXIT_CODES.ISSUES_OR_THRESHOLD);
+    const parsed = expectJsonScanReport(output);
+    expect(
+      (parsed.findings as Array<{ severity: string }>).some((f) => f.severity === "critical"),
+    ).toBe(true);
+  });
+
+  it("argv: --fail-on-severity critical passes on clean fixture", async () => {
+    const { exitCode } = await parseCli([
+      "scan",
+      cleanProject,
+      "--json",
+      "--fail-on-severity",
+      "critical",
+    ]);
+    expect(exitCode).toBe(EXIT_CODES.SUCCESS);
+  });
+
+  it("argv: --fail-on-rule matches specific rule id", async () => {
+    const { exitCode } = await parseCli([
+      "scan",
+      insecureProject,
+      "--json",
+      "--fail-on-rule",
+      "security/env-file-exposure",
+    ]);
+    expect(exitCode).toBe(EXIT_CODES.ISSUES_OR_THRESHOLD);
+  });
+
+  it("argv: invalid --fail-on-severity is a usage error", async () => {
+    const { exitCode } = await parseCli([
+      "scan",
+      cleanProject,
+      "--json",
+      "--fail-on-severity",
+      "high",
+    ]);
+    expect(exitCode).toBe(EXIT_CODES.USAGE_ERROR);
+  });
+
+  it("argv: invalid --min-score is a usage error (not internal error)", async () => {
+    const { exitCode } = await parseCli([
+      "scan",
+      cleanProject,
+      "--json",
+      "--min-score",
+      "999",
+    ]);
+    expect(exitCode).toBe(EXIT_CODES.USAGE_ERROR);
+    expect(exitCode).not.toBe(EXIT_CODES.INTERNAL_ERROR);
+  });
+
   it("argv: scan without --json emits terminal report", async () => {
     const { output, exitCode } = await parseCli(["scan", cleanProject]);
     expect(exitCode).toBe(EXIT_CODES.SUCCESS);
@@ -244,6 +327,19 @@ describe("CLI verify", () => {
     expect(exitCode).toBe(EXIT_CODES.ISSUES_OR_THRESHOLD);
     const parsed = JSON.parse(output) as { summary: { new: number } };
     expect(parsed.summary.new).toBeGreaterThan(0);
+  });
+
+  it("argv: verify --fail-on-new exits 1 when new findings appear", async () => {
+    const baselinePath = await writeBaseline(cleanProject);
+    const { exitCode } = await parseCli([
+      "verify",
+      insecureProject,
+      "--json",
+      "--fail-on-new",
+      "--baseline",
+      baselinePath,
+    ]);
+    expect(exitCode).toBe(EXIT_CODES.ISSUES_OR_THRESHOLD);
   });
 
   it("argv: verify without baseline exits usage error", async () => {

--- a/tests/unit/discovery.test.ts
+++ b/tests/unit/discovery.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { discoverFiles } from "../../src/discovery/files.js";
+import { scan } from "../../src/index.js";
 
 const tempDirs: string[] = [];
 
@@ -48,5 +49,33 @@ describe("discoverFiles", () => {
     const result = await discoverFiles({ root, maxFileSizeBytes: 100 });
     expect(result.files.map((f) => f.relativePath)).toEqual(["small.txt"]);
     expect(result.filesSkippedOversized).toBe(1);
+  });
+
+  it("keeps oversized log-like paths as metadata for context rules", async () => {
+    const root = await makeTempRepo();
+    await fs.writeFile(path.join(root, "small.txt"), "ok");
+    await fs.writeFile(path.join(root, "debug-app.log"), Buffer.alloc(1000));
+    await fs.writeFile(path.join(root, "huge.bin"), Buffer.alloc(1000));
+
+    const result = await discoverFiles({ root, maxFileSizeBytes: 100 });
+    const relatives = result.files.map((f) => f.relativePath);
+    expect(relatives).toContain("small.txt");
+    expect(relatives).toContain("debug-app.log");
+    expect(relatives).not.toContain("huge.bin");
+    expect(result.files.find((f) => f.relativePath === "debug-app.log")?.sizeBytes).toBe(1000);
+    expect(result.filesSkippedOversized).toBe(1);
+  });
+
+  it("flags oversized logs above the content-read limit (false-negative regression)", async () => {
+    const root = await makeTempRepo();
+    await fs.writeFile(path.join(root, "package.json"), '{"name":"oversized-log"}');
+    await fs.writeFile(path.join(root, "AGENTS.md"), "# agents\n");
+    // Default discovery max is 2 MiB; large-log threshold is 256 KiB.
+    await fs.writeFile(path.join(root, "debug-app.log"), Buffer.alloc(3 * 1024 * 1024));
+
+    const result = await scan({ cwd: root });
+    const finding = result.findings.find((f) => f.ruleId === "context/large-log-file");
+    expect(finding).toBeDefined();
+    expect(finding?.evidence?.path).toBe("debug-app.log");
   });
 });

--- a/tests/unit/fix/fix-next-steps.test.ts
+++ b/tests/unit/fix/fix-next-steps.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { renderFixPlanTerminal } from "../../../src/core/fix/render.js";
+import type { FixPlan } from "../../../src/core/fix/types.js";
+
+describe("fix Next steps workflow", () => {
+  it("dry-run with actions points at fix -y then verify", () => {
+    const plan: FixPlan = {
+      actions: [
+        {
+          id: "a1",
+          agent: "cursor",
+          kind: "cursorignore-append",
+          description: "Ignore dist/",
+          pattern: "dist/",
+          findingIds: ["f1"],
+          targetRelativePath: ".cursorignore",
+        },
+      ],
+      skipped: [
+        {
+          findingId: "f2",
+          ruleId: "security/env-file-exposure",
+          reason: "Requires human review (not auto-fixed)",
+        },
+      ],
+    };
+
+    const output = renderFixPlanTerminal(plan, {
+      dryRun: true,
+      cursorContent: null,
+    });
+
+    expect(output).toContain("Next");
+    expect(output).toContain("agentdoctor fix -y");
+    expect(output).toContain("agentdoctor verify --baseline agentdoctor-report.json");
+    expect(output).toContain("agentdoctor scan --json > agentdoctor-report.json");
+    expect(output).toContain("agentdoctor explain <rule-id>");
+  });
+
+  it("review-only plan points at explain and verify, not fix -y", () => {
+    const plan: FixPlan = {
+      actions: [],
+      skipped: [
+        {
+          findingId: "f2",
+          ruleId: "security/env-file-exposure",
+          reason: "Requires human review (not auto-fixed)",
+        },
+      ],
+    };
+
+    const output = renderFixPlanTerminal(plan, {
+      dryRun: true,
+      cursorContent: null,
+    });
+
+    expect(output).toContain("Next");
+    expect(output).toContain("agentdoctor explain <rule-id>");
+    expect(output).toContain("agentdoctor verify --baseline agentdoctor-report.json");
+    expect(output).not.toContain("agentdoctor fix -y");
+  });
+});

--- a/tests/unit/fix/fix-plan.test.ts
+++ b/tests/unit/fix/fix-plan.test.ts
@@ -28,7 +28,8 @@ async function makeCursorFixSandbox(options?: {
     JSON.stringify({ name: "fix-sandbox", private: true }),
     "utf8",
   );
-  await fs.writeFile(path.join(root, "AGENTS.md"), "# Agents\n\nUse AgentDoctor.\n", "utf8");
+  // Prefer legacy .cursorrules over AGENTS.md so Codex is not also detected.
+  await fs.writeFile(path.join(root, ".cursorrules"), "# Cursor\n\nUse AgentDoctor.\n", "utf8");
 
   if (options?.withBuild !== false) {
     await fs.mkdir(path.join(root, "build"), { recursive: true });
@@ -121,7 +122,10 @@ describe("fix plan + cursorignore writer", () => {
       const after = await scan({ cwd: root });
       expect(
         after.findings.some(
-          (f) => f.ruleId === "context/generated-directory" && f.evidence?.path === "build",
+          (f) =>
+            f.ruleId === "context/generated-directory" &&
+            f.evidence?.path === "build" &&
+            f.affectedAgents.includes("cursor"),
         ),
       ).toBe(false);
     } finally {
@@ -193,4 +197,163 @@ describe("fix plan + cursorignore writer", () => {
       ),
     ).toBe(true);
   });
+
+  it("proposes Claude Read deny for safe context findings when Claude Code is configured", async () => {
+    const root = await makeClaudeFixSandbox();
+    try {
+      const result = await scan({ cwd: root });
+      expect(
+        result.findings.some(
+          (f) =>
+            f.ruleId === "context/generated-directory" &&
+            f.evidence?.path === "build" &&
+            f.affectedAgents.includes("claude-code"),
+        ),
+      ).toBe(true);
+
+      const plan = await buildFixPlan(result);
+      expect(
+        plan.actions.some(
+          (a) =>
+            a.agent === "claude-code" &&
+            a.targetRelativePath === ".claude/settings.json" &&
+            a.pattern === "build/",
+        ),
+      ).toBe(true);
+      expect(plan.actions.every((a) => a.agent !== "cursor")).toBe(true);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("apply writes Claude settings deny and clears generated-directory for Claude", async () => {
+    const root = await makeClaudeFixSandbox();
+    try {
+      const before = await scan({ cwd: root });
+      const plan = await buildFixPlan(before);
+      const applyResult = await applyFixPlan(plan, { dryRun: false });
+      expect(applyResult.writtenFiles).toEqual([".claude/settings.json"]);
+
+      const written = JSON.parse(
+        await fs.readFile(path.join(root, ".claude/settings.json"), "utf8"),
+      );
+      expect(written.permissions.deny).toContain("Read(./build/**)");
+
+      const after = await scan({ cwd: root });
+      expect(
+        after.findings.some(
+          (f) =>
+            f.ruleId === "context/generated-directory" &&
+            f.evidence?.path === "build" &&
+            f.affectedAgents.includes("claude-code"),
+        ),
+      ).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("proposes Codex filesystem deny for safe context findings when Codex is detected", async () => {
+    const root = await makeCodexFixSandbox();
+    try {
+      const result = await scan({ cwd: root });
+      expect(
+        result.findings.some(
+          (f) =>
+            f.ruleId === "context/generated-directory" &&
+            f.evidence?.path === "build" &&
+            f.affectedAgents.includes("codex"),
+        ),
+      ).toBe(true);
+
+      const plan = await buildFixPlan(result);
+      expect(
+        plan.actions.some(
+          (a) =>
+            a.agent === "codex" &&
+            a.targetRelativePath === ".codex/config.toml" &&
+            a.pattern === "build/",
+        ),
+      ).toBe(true);
+      expect(plan.actions.every((a) => a.agent === "codex")).toBe(true);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("apply writes Codex config deny and clears generated-directory for Codex", async () => {
+    const root = await makeCodexFixSandbox();
+    try {
+      const before = await scan({ cwd: root });
+      const plan = await buildFixPlan(before);
+      const applyResult = await applyFixPlan(plan, { dryRun: false });
+      expect(applyResult.writtenFiles).toEqual([".codex/config.toml"]);
+
+      const written = await fs.readFile(path.join(root, ".codex", "config.toml"), "utf8");
+      expect(written).toContain('default_permissions = "agentdoctor_context"');
+      expect(written).toContain('"build" = "deny"');
+
+      const after = await scan({ cwd: root });
+      expect(
+        after.findings.some(
+          (f) =>
+            f.ruleId === "context/generated-directory" &&
+            f.evidence?.path === "build" &&
+            f.affectedAgents.includes("codex"),
+        ),
+      ).toBe(false);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses Codex Fix when sandbox_mode is present", async () => {
+    const root = await makeCodexFixSandbox({
+      existingConfig: 'sandbox_mode = "workspace-write"\n',
+    });
+    try {
+      const result = await scan({ cwd: root });
+      await expect(buildFixPlan(result)).rejects.toThrow(/sandbox_mode/);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });
+
+async function makeClaudeFixSandbox(): Promise<string> {
+  await fs.mkdir(scratchRoot, { recursive: true });
+  const root = await fs.mkdtemp(path.join(scratchRoot, "fix-claude-"));
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "fix-claude-sandbox", private: true }),
+    "utf8",
+  );
+  await fs.writeFile(path.join(root, "CLAUDE.md"), "# Claude\n\nProject guidance.\n", "utf8");
+  await fs.mkdir(path.join(root, ".claude"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, ".claude", "settings.json"),
+    JSON.stringify({ permissions: { deny: [] } }, null, 2),
+    "utf8",
+  );
+  await fs.mkdir(path.join(root, "build"), { recursive: true });
+  await fs.writeFile(path.join(root, "build", "out.txt"), "generated\n", "utf8");
+  return root;
+}
+
+/** Codex-only: `.codex/` without AGENTS.md (AGENTS.md would also configure Cursor). */
+async function makeCodexFixSandbox(options?: { existingConfig?: string }): Promise<string> {
+  await fs.mkdir(scratchRoot, { recursive: true });
+  const root = await fs.mkdtemp(path.join(scratchRoot, "fix-codex-"));
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "fix-codex-sandbox", private: true }),
+    "utf8",
+  );
+  await fs.mkdir(path.join(root, ".codex"), { recursive: true });
+  if (options?.existingConfig !== undefined) {
+    await fs.writeFile(path.join(root, ".codex", "config.toml"), options.existingConfig, "utf8");
+  }
+  await fs.mkdir(path.join(root, "build"), { recursive: true });
+  await fs.writeFile(path.join(root, "build", "out.txt"), "generated\n", "utf8");
+  return root;
+}

--- a/tests/unit/hardening/release-hardening.test.ts
+++ b/tests/unit/hardening/release-hardening.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runFixCommand } from "../../../src/cli/commands/fix.js";
+import { runScanCommand } from "../../../src/cli/commands/scan.js";
+import { buildCodexConfigContent } from "../../../src/core/fix/writers/codex-config.js";
+import { renderTerminalReport } from "../../../src/reporters/terminal/report.js";
+import { scan } from "../../../src/index.js";
+import { EXIT_CODES } from "../../../src/types/index.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+
+async function makeTemp(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agentdoctor-harden-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("release hardening regressions", () => {
+  it("min-score fails on agentless repository instead of vacuous 100", async () => {
+    const root = await makeTemp();
+    const code = await runScanCommand({
+      targetPath: root,
+      json: true,
+      minScore: 70,
+    });
+    expect(code).toBe(EXIT_CODES.ISSUES_OR_THRESHOLD);
+  });
+
+  it("terminal readiness is n/a when no agents are configured", async () => {
+    const root = await makeTemp();
+    const result = await scan({ cwd: root });
+    expect(result.agentSecurityAnalysis).toBe("limited");
+    const terminal = renderTerminalReport(result);
+    expect(terminal).toContain("Readiness: n/a");
+    expect(terminal).not.toMatch(/Readiness: 100\/100/);
+    expect(terminal).toContain("Nothing to audit yet");
+    expect(terminal).toContain("Next: add project agent config");
+  });
+
+  it("Codex Fix refuses unrecognizable config.toml content", () => {
+    expect(() => buildCodexConfigContent("this is not = toml [[[\n", ["build"])).toThrow(
+      /does not look like valid Codex config TOML/,
+    );
+  });
+
+  it("Codex Fix still initializes comment-only config.toml", () => {
+    const after = buildCodexConfigContent("# project notes\n", ["build"]);
+    expect(after).toContain('default_permissions = "agentdoctor_context"');
+    expect(after).toContain('"build" = "deny"');
+  });
+
+  it("fix without --yes on non-TTY exits usage error", async () => {
+    const root = await makeTemp();
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "x" }), "utf8");
+    await fs.writeFile(path.join(root, ".cursorrules"), "# cursor\n", "utf8");
+    await fs.mkdir(path.join(root, "build"));
+    await fs.writeFile(path.join(root, "build", "out.txt"), "g\n", "utf8");
+
+    const code = await runFixCommand({ targetPath: root, yes: false, dryRun: false });
+    expect(code).toBe(EXIT_CODES.USAGE_ERROR);
+  });
+
+  it("fix on invalid Claude settings exits usage error", async () => {
+    const root = await makeTemp();
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "x" }), "utf8");
+    await fs.writeFile(path.join(root, "CLAUDE.md"), "# Claude\n", "utf8");
+    await fs.mkdir(path.join(root, ".claude"));
+    await fs.writeFile(path.join(root, ".claude", "settings.json"), "{broken", "utf8");
+    await fs.mkdir(path.join(root, "build"));
+    await fs.writeFile(path.join(root, "build", "out.txt"), "g\n", "utf8");
+
+    const code = await runFixCommand({ targetPath: root, yes: true, dryRun: false });
+    expect(code).toBe(EXIT_CODES.USAGE_ERROR);
+  });
+
+  it("fix on garbage Codex config.toml exits usage error (no partial Cursor-only write)", async () => {
+    const root = await makeTemp();
+    await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "x" }), "utf8");
+    await fs.writeFile(path.join(root, "AGENTS.md"), "# agents\n", "utf8");
+    await fs.mkdir(path.join(root, ".codex"));
+    await fs.writeFile(path.join(root, ".codex", "config.toml"), "[[[not-toml\n", "utf8");
+    await fs.mkdir(path.join(root, "build"));
+    await fs.writeFile(path.join(root, "build", "out.txt"), "g\n", "utf8");
+
+    const code = await runFixCommand({ targetPath: root, yes: true, dryRun: false });
+    expect(code).toBe(EXIT_CODES.USAGE_ERROR);
+    await expect(fs.access(path.join(root, ".cursorignore"))).rejects.toThrow();
+    const codex = await fs.readFile(path.join(root, ".codex", "config.toml"), "utf8");
+    expect(codex).toBe("[[[not-toml\n");
+  });
+});

--- a/tests/unit/path-resolution/prepare.test.ts
+++ b/tests/unit/path-resolution/prepare.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  isConcretePathReference,
+  normalizePathReference,
+  preparePathReference,
+} from "../../../src/core/path-resolution/index.js";
+import { scan } from "../../../src/index.js";
+
+const tempDirs: string[] = [];
+
+async function tempRepo(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agentdoctor-path-prep-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+
+function missingPathFindings(result: Awaited<ReturnType<typeof scan>>) {
+  return result.findings.filter((f) => f.ruleId === "instructions/missing-path-reference");
+}
+
+describe("normalizePathReference", () => {
+  it("URI-decodes and unifies separators", () => {
+    expect(normalizePathReference("docs/architecture%20docs/adrs/")).toBe(
+      "docs/architecture docs/adrs/",
+    );
+    expect(normalizePathReference("artifacts\\agent-sentinel.txt")).toBe(
+      "artifacts/agent-sentinel.txt",
+    );
+  });
+
+  it("returns null for malformed percent-encoding", () => {
+    expect(normalizePathReference("docs/%E0%A4%A")).toBeNull();
+  });
+});
+
+describe("preparePathReference Stage 1", () => {
+  it("rejects placeholders, ellipsis, home, git-ref shapes, and bundler module types", () => {
+    expect(preparePathReference(".agents/rules/<rule-name>.mdc").status).toBe("reject");
+    expect(preparePathReference("packages/core/<package>/migrations/").status).toBe("reject");
+    expect(preparePathReference("skills-contrib/{skill}/SKILL.md").status).toBe("reject");
+    expect(preparePathReference("bases/base/...")).toMatchObject({
+      status: "reject",
+      reason: "ellipsis",
+    });
+    expect(preparePathReference("~/bashrc")).toMatchObject({ status: "reject", reason: "home" });
+    expect(preparePathReference("origin/main")).toMatchObject({
+      status: "reject",
+      reason: "git-ref",
+    });
+    expect(preparePathReference("feature/new-cli-command")).toMatchObject({
+      status: "reject",
+      reason: "git-ref",
+    });
+    expect(preparePathReference("asset/webmanifest")).toMatchObject({
+      status: "reject",
+      reason: "bundler-module-type",
+    });
+    expect(isConcretePathReference("docs/API.md")).toBe(true);
+  });
+
+  it("keeps concrete paths and exposes normalized form", () => {
+    const prepared = preparePathReference("docs/architecture%20docs/patterns/x.md");
+    expect(prepared).toEqual({
+      status: "concrete",
+      original: "docs/architecture%20docs/patterns/x.md",
+      normalized: "docs/architecture docs/patterns/x.md",
+    });
+  });
+});
+
+describe("missing-path Stage 1 integration", () => {
+  it("does not flag intentional placeholders", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(
+      path.join(root, "AGENTS.md"),
+      "Add `.agents/rules/<rule-name>.mdc` and `schemas/plugins/<Name>.json`.\n",
+    );
+
+    expect(missingPathFindings(await scan({ cwd: root }))).toHaveLength(0);
+  });
+
+  it("does not flag URI-encoded links that exist after decode", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.mkdir(path.join(root, "docs", "architecture docs", "patterns"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "docs", "architecture docs", "patterns", "frozen.md"),
+      "# ok\n",
+    );
+    await fs.writeFile(
+      path.join(root, "AGENTS.md"),
+      "See [frozen](docs/architecture%20docs/patterns/frozen.md).\n",
+    );
+
+    expect(missingPathFindings(await scan({ cwd: root }))).toHaveLength(0);
+  });
+
+  it("still flags a real missing concrete path", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(path.join(root, "AGENTS.md"), "Open `docs/still-missing.md`.\n");
+
+    const findings = missingPathFindings(await scan({ cwd: root }));
+    expect(findings.some((f) => f.evidence?.detail?.includes("docs/still-missing.md"))).toBe(true);
+  });
+
+  it("does not flag git-ref shaped backticks", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(
+      path.join(root, "AGENTS.md"),
+      "Compare against `origin/main` then branch `fix/bug-in-worker-threads`.\n",
+    );
+
+    expect(missingPathFindings(await scan({ cwd: root }))).toHaveLength(0);
+  });
+});

--- a/tests/unit/policy/evaluate.test.ts
+++ b/tests/unit/policy/evaluate.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluatePolicy,
+  evaluateScanPolicy,
+  parseFailOnRules,
+  parseSeverityGate,
+  severityRank,
+} from "../../../src/core/policy/evaluate.js";
+import type { Finding, ScanResult, Scores } from "../../../src/types/index.js";
+
+function finding(partial: Partial<Finding> & Pick<Finding, "id" | "ruleId" | "severity">): Finding {
+  return {
+    category: "security",
+    title: partial.title ?? partial.ruleId,
+    message: partial.message ?? partial.ruleId,
+    whyItMatters: "test",
+    affectedAgents: ["cursor"],
+    fixability: "review",
+    ...partial,
+  };
+}
+
+function scores(overall: number): Scores {
+  return {
+    overall,
+    categories: {
+      security: overall,
+      context: 100,
+      instructions: 100,
+      mcp: 100,
+      compatibility: 100,
+      performance: 100,
+    },
+    agents: { cursor: 100, "claude-code": 100, codex: 100 },
+  };
+}
+
+describe("policy evaluate", () => {
+  it("ranks severities deterministically", () => {
+    expect(severityRank("critical")).toBeGreaterThan(severityRank("warning"));
+    expect(severityRank("warning")).toBeGreaterThan(severityRank("info"));
+  });
+
+  it("parses severity and rule lists", () => {
+    expect(parseSeverityGate("Critical")).toBe("critical");
+    expect(parseFailOnRules(" a/b , c/d ")).toEqual(["a/b", "c/d"]);
+    expect(() => parseSeverityGate("high")).toThrow(/fail-on-severity/);
+  });
+
+  it("fails minimum-score when overall is below threshold", () => {
+    const violations = evaluatePolicy({ findings: [], scores: scores(84) }, { minimumScore: 90 });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.code).toBe("minimum-score");
+    expect(violations[0]?.message).toContain("84");
+    expect(violations[0]?.message).toContain("90");
+  });
+
+  it("passes minimum-score when overall meets threshold", () => {
+    expect(evaluatePolicy({ findings: [], scores: scores(90) }, { minimumScore: 90 })).toEqual([]);
+  });
+
+  it("fails fail-on-severity for matching and higher severities", () => {
+    const findings = [
+      finding({ id: "1", ruleId: "security/env-file-exposure", severity: "critical" }),
+      finding({ id: "2", ruleId: "context/large-log-file", severity: "info" }),
+    ];
+    const criticalGate = evaluatePolicy(
+      { findings, scores: scores(50) },
+      { failOnSeverity: "critical" },
+    );
+    expect(criticalGate).toHaveLength(1);
+    expect(criticalGate[0]?.code).toBe("fail-on-severity");
+    expect(criticalGate[0]?.details).toEqual(["security/env-file-exposure"]);
+
+    const warningGate = evaluatePolicy(
+      { findings, scores: scores(50) },
+      { failOnSeverity: "warning" },
+    );
+    expect(warningGate[0]?.details).toEqual(["security/env-file-exposure"]);
+
+    const infoGate = evaluatePolicy({ findings, scores: scores(50) }, { failOnSeverity: "info" });
+    expect(infoGate[0]?.details).toEqual(["context/large-log-file", "security/env-file-exposure"]);
+  });
+
+  it("fails fail-on-rule only for listed rule ids", () => {
+    const findings = [
+      finding({ id: "1", ruleId: "security/env-file-exposure", severity: "critical" }),
+      finding({ id: "2", ruleId: "mcp/malformed-config", severity: "warning" }),
+    ];
+    const violations = evaluatePolicy(
+      { findings, scores: scores(40) },
+      { failOnRules: ["mcp/malformed-config"] },
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.code).toBe("fail-on-rule");
+    expect(violations[0]?.details).toEqual(["mcp/malformed-config"]);
+  });
+
+  it("fails fail-on-new when new findings exist", () => {
+    const violations = evaluatePolicy(
+      { findings: [], scores: scores(100), newFindingCount: 2 },
+      { failOnNew: true },
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.code).toBe("fail-on-new");
+  });
+
+  it("aggregates multiple gates in stable order", () => {
+    const findings = [
+      finding({ id: "1", ruleId: "security/env-file-exposure", severity: "critical" }),
+    ];
+    const violations = evaluatePolicy(
+      { findings, scores: scores(10), newFindingCount: 1 },
+      {
+        minimumScore: 90,
+        failOnSeverity: "critical",
+        failOnRules: ["security/env-file-exposure"],
+        failOnNew: true,
+      },
+    );
+    expect(violations.map((v) => v.code)).toEqual([
+      "minimum-score",
+      "fail-on-severity",
+      "fail-on-rule",
+      "fail-on-new",
+    ]);
+  });
+
+  it("evaluateScanPolicy ignores failOnNew", () => {
+    const result = {
+      findings: [] as Finding[],
+      scores: scores(100),
+      agentSecurityAnalysis: "full" as const,
+    } as ScanResult;
+    expect(evaluateScanPolicy(result, { failOnNew: true, minimumScore: 50 })).toEqual([]);
+  });
+
+  it("fails minimum-score when agent analysis is limited", () => {
+    const violations = evaluatePolicy(
+      { findings: [], scores: scores(100), agentSecurityAnalysis: "limited" },
+      { minimumScore: 70 },
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.code).toBe("minimum-score");
+    expect(violations[0]?.message).toContain("no supported coding-agent configuration");
+  });
+});

--- a/tests/unit/policy/performance.test.ts
+++ b/tests/unit/policy/performance.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluatePolicy } from "../../../src/core/policy/evaluate.js";
+import type { Finding, Scores } from "../../../src/types/index.js";
+
+/**
+ * Micro-benchmark: policy evaluation must stay negligible vs scan time.
+ */
+describe("policy performance", () => {
+  it("evaluates large finding sets in well under 50ms", () => {
+    const findings: Finding[] = [];
+    for (let i = 0; i < 5000; i += 1) {
+      findings.push({
+        id: `f${i}`,
+        ruleId: i % 7 === 0 ? "security/env-file-exposure" : `context/rule-${i % 20}`,
+        category: i % 7 === 0 ? "security" : "context",
+        severity: i % 11 === 0 ? "critical" : i % 3 === 0 ? "warning" : "info",
+        title: "t",
+        message: "m",
+        whyItMatters: "w",
+        affectedAgents: ["cursor"],
+        fixability: "review",
+        evidence: { path: `path/${i}` },
+      });
+    }
+    const scores: Scores = {
+      overall: 42,
+      categories: {
+        security: 40,
+        context: 50,
+        instructions: 60,
+        mcp: 70,
+        compatibility: 80,
+        performance: 90,
+      },
+      agents: { cursor: 40, "claude-code": 40, codex: 40 },
+    };
+
+    const started = performance.now();
+    const violations = evaluatePolicy(
+      { findings, scores, newFindingCount: 12 },
+      {
+        minimumScore: 90,
+        failOnSeverity: "warning",
+        failOnRules: ["security/env-file-exposure"],
+        failOnNew: true,
+      },
+    );
+    const elapsedMs = performance.now() - started;
+
+    expect(violations.length).toBe(4);
+    expect(elapsedMs).toBeLessThan(50);
+  });
+});

--- a/tests/unit/reporters/github.test.ts
+++ b/tests/unit/reporters/github.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { emitGithubReports } from "../../../src/reporters/github/emit.js";
+import { renderGithubAnnotations } from "../../../src/reporters/github/annotations.js";
+import { renderGithubStepSummary } from "../../../src/reporters/github/summary.js";
+import type { Finding } from "../../../src/types/index.js";
+
+const sampleFindings: Finding[] = [
+  {
+    id: "f1",
+    ruleId: "security/env-file-exposure",
+    category: "security",
+    severity: "critical",
+    title: "Sensitive environment file may enter agent context",
+    message: ".env may be readable",
+    whyItMatters: "secrets",
+    affectedAgents: ["cursor"],
+    evidence: { path: ".env", line: 1 },
+    fixability: "review",
+  },
+  {
+    id: "f2",
+    ruleId: "context/generated-directory",
+    category: "context",
+    severity: "info",
+    title: "Generated directory may enter agent context",
+    message: "build/ present",
+    whyItMatters: "noise",
+    affectedAgents: ["codex"],
+    evidence: { path: "build" },
+    fixability: "safe",
+  },
+];
+
+describe("github reporters", () => {
+  it("renders workflow annotations to stderr-safe commands", () => {
+    const text = renderGithubAnnotations(sampleFindings);
+    expect(text).toContain("::error file=.env,line=1,title=");
+    expect(text).toContain("security/env-file-exposure");
+    expect(text).toContain("::notice file=build,title=");
+    expect(text.split("\n").filter(Boolean)).toHaveLength(2);
+  });
+
+  it("renders step summary markdown with policy section", () => {
+    const md = renderGithubStepSummary({
+      title: "AgentDoctor Scan",
+      overallScore: 84,
+      findings: sampleFindings,
+      violations: [
+        {
+          code: "minimum-score",
+          message: "CI check failed: overall score 84 is below --min-score 90",
+        },
+      ],
+      mode: "scan",
+    });
+    expect(md).toContain("**Readiness:** 84/100");
+    expect(md).toContain("Policy violations");
+    expect(md).toContain("below --min-score 90");
+    expect(md).toContain("`security/env-file-exposure`");
+    expect(md).toContain("## Next");
+    expect(md).toContain("scan --ci");
+    expect(md).toContain("fix -y");
+  });
+
+  it("omits Next section when policy gates pass", () => {
+    const md = renderGithubStepSummary({
+      title: "AgentDoctor Scan",
+      overallScore: 95,
+      findings: sampleFindings,
+      violations: [],
+      mode: "scan",
+    });
+    expect(md).toContain("Policy gates: **passed**");
+    expect(md).not.toContain("## Next");
+  });
+
+  it("emitGithubReports writes summary file and annotations", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agentdoctor-gh-"));
+    const summaryPath = path.join(dir, "summary.md");
+    const annotations: string[] = [];
+    try {
+      await emitGithubReports({
+        mode: "scan",
+        findings: sampleFindings,
+        overallScore: 70,
+        violations: [],
+        summary: true,
+        annotations: true,
+        stepSummaryPath: summaryPath,
+        annotationsWrite: (chunk) => annotations.push(chunk),
+      });
+      const summary = await fs.readFile(summaryPath, "utf8");
+      expect(summary).toContain("Policy gates: **passed**");
+      expect(annotations.join("")).toContain("::error");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/reporters/terminal-next-steps.test.ts
+++ b/tests/unit/reporters/terminal-next-steps.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { scan } from "../../../src/index.js";
+import { renderTerminalReport } from "../../../src/reporters/terminal/report.js";
+
+const tempDirs: string[] = [];
+
+async function tempRepo(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "agentdoctor-next-steps-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((d) => fs.rm(d, { recursive: true, force: true })));
+});
+
+describe("terminal Next steps workflow", () => {
+  it("points review-only findings at explain/verify instead of implying Fix will apply", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(path.join(root, "AGENTS.md"), "demo\n");
+    await fs.writeFile(path.join(root, ".env"), "SECRET=1\n");
+
+    const output = renderTerminalReport(await scan({ cwd: root }));
+
+    expect(output).toContain("Next");
+    expect(output).toMatch(/\[review\]/);
+    expect(output).toMatch(/need review or manual action/);
+    expect(output).toContain("agentdoctor fix");
+    expect(output).toContain("will not change them automatically");
+    expect(output).toContain("agentdoctor scan --json > agentdoctor-report.json");
+    expect(output).toContain("agentdoctor verify --baseline agentdoctor-report.json");
+    expect(output).not.toContain("agentdoctor fix --dry-run");
+  });
+
+  it("points safe findings at fix --dry-run", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(path.join(root, "AGENTS.md"), "demo\n");
+    await fs.mkdir(path.join(root, "dist"), { recursive: true });
+    await fs.writeFile(path.join(root, "dist/out.js"), "1\n");
+
+    const output = renderTerminalReport(await scan({ cwd: root }));
+
+    expect(output).toContain("Next");
+    expect(output).toMatch(/\[safe\]/);
+    expect(output).toContain("agentdoctor fix --dry-run");
+    expect(output).toContain("agentdoctor fix -y");
+    expect(output).toContain("agentdoctor verify --baseline agentdoctor-report.json");
+  });
+
+  it("does not add a Next block when there are no findings and agents are configured", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(path.join(root, "AGENTS.md"), "Keep secrets out of agent context.\n");
+
+    const output = renderTerminalReport(await scan({ cwd: root }));
+    expect(output).toContain("No findings");
+    expect(output).not.toMatch(/\nNext\n/);
+  });
+});

--- a/tests/unit/rules/path-kind.test.ts
+++ b/tests/unit/rules/path-kind.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  isCheckedInGithubActionDist,
   isSampleOrTestPath,
   isSourceNamedArtifactCollision,
 } from "../../../src/core/rules/path-kind.js";
@@ -37,21 +38,49 @@ describe("isSampleOrTestPath", () => {
     );
   });
 
+  it("detects hyphenated, underscored, camelCase, and leading-underscore test trees", () => {
+    expect(
+      isSampleOrTestPath(
+        "integration-test/spring-boot-sni-integration-tests/app/resources/test-hello-server.key",
+      ),
+    ).toBe(true);
+    expect(isSampleOrTestPath("module/amqp/src/dockerTest/resources/server.key")).toBe(true);
+    expect(isSampleOrTestPath("module/mail/src/testFixtures/resources/test-key.pem")).toBe(true);
+    expect(isSampleOrTestPath("smoke-test/kafka/ssl.key")).toBe(true);
+    expect(isSampleOrTestPath("_fixture/certs/key.pem")).toBe(true);
+    expect(isSampleOrTestPath("packages/demo/integration_tests/tls/server.key")).toBe(true);
+    expect(isSampleOrTestPath("services/api/docker-test/certs/client.p12")).toBe(true);
+    expect(isSampleOrTestPath("app/src/httpTest/resources/server.key")).toBe(true);
+    expect(isSampleOrTestPath("playground/env/.env")).toBe(true);
+    expect(isSampleOrTestPath("packages/vite/playgrounds/ssr/.env.development")).toBe(true);
+    expect(isSampleOrTestPath("bench/vercel/.env.dev")).toBe(true);
+    expect(isSampleOrTestPath("examples/with-env/.env")).toBe(true);
+    expect(isSampleOrTestPath("sandbox/demo-app/.env")).toBe(true);
+  });
+
   it("does not treat production roots as samples", () => {
     expect(isSampleOrTestPath(".env")).toBe(false);
     expect(isSampleOrTestPath("config/.env")).toBe(false);
     expect(isSampleOrTestPath("test-private-key.pem")).toBe(false);
     expect(isSampleOrTestPath("app-signing.pem")).toBe(false);
     expect(isSampleOrTestPath("docs-assets/app/.env")).toBe(false);
+    expect(isSampleOrTestPath("config/certs/server.key")).toBe(false);
+    expect(isSampleOrTestPath("deploy/secrets/id_rsa")).toBe(false);
+    expect(isSampleOrTestPath("src/main/resources/keystore.p12")).toBe(false);
   });
 });
 
 describe("isSourceNamedArtifactCollision", () => {
-  it("detects source packages named build/target under code parents", () => {
+  it("detects source packages named build/target/vendor under code parents or src ancestors", () => {
     expect(isSourceNamedArtifactCollision("scripts/build")).toBe(true);
     expect(isSourceNamedArtifactCollision("internal/build")).toBe(true);
     expect(isSourceNamedArtifactCollision("cmd/build")).toBe(true);
     expect(isSourceNamedArtifactCollision("src/target")).toBe(true);
+    expect(isSourceNamedArtifactCollision("packages/astro/src/core/build")).toBe(true);
+    expect(isSourceNamedArtifactCollision("packages/astro/src/assets/utils/vendor")).toBe(true);
+    expect(isSourceNamedArtifactCollision("adev/src/assets/images/guide/build")).toBe(true);
+    expect(isSourceNamedArtifactCollision("src/Mvc/build")).toBe(true);
+    expect(isSourceNamedArtifactCollision("src/node-fallbacks/vendor")).toBe(true);
   });
 
   it("keeps real generated build/dist paths", () => {
@@ -59,6 +88,18 @@ describe("isSourceNamedArtifactCollision", () => {
     expect(isSourceNamedArtifactCollision("packages/actions/dist")).toBe(false);
     expect(isSourceNamedArtifactCollision("apps/web/build")).toBe(false);
     expect(isSourceNamedArtifactCollision("frontend/build")).toBe(false);
+    expect(isSourceNamedArtifactCollision("packages/foo/src/js/dist")).toBe(false);
+    expect(isSourceNamedArtifactCollision("packages/react-router/vendor")).toBe(false);
+  });
+});
+
+describe("isCheckedInGithubActionDist", () => {
+  it("detects Action package dist folders only", () => {
+    expect(isCheckedInGithubActionDist(".github/actions/needs-triage/dist")).toBe(true);
+    expect(isCheckedInGithubActionDist(".github/actions/validate-docs-links/dist")).toBe(true);
+    expect(isCheckedInGithubActionDist(".github/workflows/dist")).toBe(false);
+    expect(isCheckedInGithubActionDist("packages/actions/dist")).toBe(false);
+    expect(isCheckedInGithubActionDist(".github/actions/needs-triage/src")).toBe(false);
   });
 });
 
@@ -125,6 +166,80 @@ describe("sample/test path suppression across security rules", () => {
     expect(generated.some((f) => f.evidence?.path === "dist")).toBe(true);
   });
 
+  it("skips hyphenated and camelCase TLS test trees but keeps production keys", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(path.join(root, "AGENTS.md"), "demo\n");
+    await fs.mkdir(path.join(root, "config/certs"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "config/certs/server.key"),
+      "-----BEGIN PRIVATE KEY-----\nP\n",
+    );
+    await fs.mkdir(path.join(root, "integration-test/app/resources"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "integration-test/app/resources/test-hello-server.key"),
+      "-----BEGIN PRIVATE KEY-----\nT\n",
+    );
+    await fs.mkdir(path.join(root, "module/src/dockerTest/resources"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "module/src/dockerTest/resources/server.key"),
+      "-----BEGIN PRIVATE KEY-----\nD\n",
+    );
+    await fs.mkdir(path.join(root, "module/src/testFixtures/resources"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "module/src/testFixtures/resources/test-key.pem"),
+      "-----BEGIN PRIVATE KEY-----\nF\n",
+    );
+    await fs.mkdir(path.join(root, "_fixture/certs"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "_fixture/certs/key.pem"),
+      "-----BEGIN PRIVATE KEY-----\nU\n",
+    );
+    await fs.mkdir(path.join(root, "smoke-test/ssl"), { recursive: true });
+    await fs.writeFile(path.join(root, "smoke-test/ssl/ssl.key"), "-----BEGIN PRIVATE KEY-----\nS\n");
+
+    const result = await scan({ cwd: root });
+    const keys = result.findings.filter((f) => f.ruleId === "security/private-key-file");
+    const paths = keys.map((f) => f.evidence?.path);
+
+    expect(paths).toContain("config/certs/server.key");
+    expect(paths).not.toContain("integration-test/app/resources/test-hello-server.key");
+    expect(paths).not.toContain("module/src/dockerTest/resources/server.key");
+    expect(paths).not.toContain("module/src/testFixtures/resources/test-key.pem");
+    expect(paths).not.toContain("_fixture/certs/key.pem");
+    expect(paths).not.toContain("smoke-test/ssl/ssl.key");
+  });
+
+  it("skips playground and bench .env fixtures but keeps production .env", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(path.join(root, "AGENTS.md"), "demo\n");
+    await fs.writeFile(path.join(root, ".env"), "SECRET=prod\n");
+    await fs.mkdir(path.join(root, "config"), { recursive: true });
+    await fs.writeFile(path.join(root, "config/.env"), "SECRET=config\n");
+    await fs.mkdir(path.join(root, "playground/env"), { recursive: true });
+    await fs.writeFile(path.join(root, "playground/env/.env"), "VITE_DEMO=1\n");
+    await fs.writeFile(path.join(root, "playground/env/.env.development"), "VITE_DEMO=1\n");
+    await fs.mkdir(path.join(root, "bench/vercel"), { recursive: true });
+    await fs.writeFile(path.join(root, "bench/vercel/.env.dev"), "TOKEN=bench\n");
+    await fs.mkdir(path.join(root, "examples/with-env"), { recursive: true });
+    await fs.writeFile(path.join(root, "examples/with-env/.env"), "DEMO=1\n");
+    await fs.mkdir(path.join(root, "sandbox/app"), { recursive: true });
+    await fs.writeFile(path.join(root, "sandbox/app/.env"), "DEMO=1\n");
+
+    const result = await scan({ cwd: root });
+    const env = result.findings.filter((f) => f.ruleId === "security/env-file-exposure");
+    const paths = env.map((f) => f.evidence?.path);
+
+    expect(paths).toContain(".env");
+    expect(paths).toContain("config/.env");
+    expect(paths).not.toContain("playground/env/.env");
+    expect(paths).not.toContain("playground/env/.env.development");
+    expect(paths).not.toContain("bench/vercel/.env.dev");
+    expect(paths).not.toContain("examples/with-env/.env");
+    expect(paths).not.toContain("sandbox/app/.env");
+  });
+
   it("does not label scripts/build or internal/build as generated output", async () => {
     const root = await tempRepo();
     await fs.writeFile(path.join(root, "package.json"), "{}\n");
@@ -142,5 +257,31 @@ describe("sample/test path suppression across security rules", () => {
     expect(generated.every((f) => f.evidence?.path !== "scripts/build")).toBe(true);
     expect(generated.every((f) => f.evidence?.path !== "internal/build")).toBe(true);
     expect(generated.some((f) => f.evidence?.path === "frontend/build")).toBe(true);
+  });
+
+  it("skips source-named build/vendor under src and checked-in Action dist", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.writeFile(path.join(root, "AGENTS.md"), "demo\n");
+    await fs.mkdir(path.join(root, "packages/lib/src/core/build"), { recursive: true });
+    await fs.writeFile(path.join(root, "packages/lib/src/core/build/index.ts"), "export {}\n");
+    await fs.mkdir(path.join(root, "packages/lib/src/utils/vendor"), { recursive: true });
+    await fs.writeFile(path.join(root, "packages/lib/src/utils/vendor/x.js"), "1\n");
+    await fs.mkdir(path.join(root, ".github/actions/needs-triage/dist"), { recursive: true });
+    await fs.writeFile(path.join(root, ".github/actions/needs-triage/dist/index.js"), "1\n");
+    await fs.mkdir(path.join(root, "packages/ui/dist"), { recursive: true });
+    await fs.writeFile(path.join(root, "packages/ui/dist/index.js"), "1\n");
+    await fs.mkdir(path.join(root, "build"), { recursive: true });
+    await fs.writeFile(path.join(root, "build/out.js"), "1\n");
+
+    const result = await scan({ cwd: root });
+    const generated = result.findings.filter((f) => f.ruleId === "context/generated-directory");
+    const paths = generated.map((f) => f.evidence?.path);
+
+    expect(paths).not.toContain("packages/lib/src/core/build");
+    expect(paths).not.toContain("packages/lib/src/utils/vendor");
+    expect(paths).not.toContain(".github/actions/needs-triage/dist");
+    expect(paths).toContain("packages/ui/dist");
+    expect(paths).toContain("build");
   });
 });

--- a/tests/unit/rules/security-semantics-013.test.ts
+++ b/tests/unit/rules/security-semantics-013.test.ts
@@ -40,8 +40,12 @@ describe("security semantics: agents vs repository risk", () => {
 
     const terminal = renderTerminalReport(result);
     expect(terminal).toContain("agent-specific security exposure checks are limited");
-    expect(terminal).toContain("No agent-configuration findings");
+    expect(terminal).toContain("Nothing to audit yet");
+    expect(terminal).toContain("re-run `agentdoctor`");
+    expect(terminal).not.toContain("No agent-configuration findings");
+    expect(terminal).toContain("Readiness: n/a");
     expect(terminal).not.toContain("No findings");
+    expect(terminal).not.toMatch(/Readiness: \d+\/100/);
 
     const json = JSON.parse(renderJsonReport(result));
     expect(json.agentSecurityAnalysis).toBe("limited");

--- a/tests/unit/verify/verify-next-steps.test.ts
+++ b/tests/unit/verify/verify-next-steps.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import type { VerifyResult } from "../../../src/core/verify/verify.js";
+import {
+  renderVerifyNextSteps,
+  renderVerifyTerminalReport,
+} from "../../../src/reporters/verify/terminal.js";
+import type { ScanResult } from "../../../src/types/index.js";
+
+function emptyScan(): ScanResult {
+  return {
+    version: "0.0.0-test",
+    repository: {
+      root: "/tmp",
+      filesScanned: 0,
+      primaryFramework: "unknown",
+      frameworks: ["unknown"],
+      primaryLanguage: "unknown",
+      languages: ["unknown"],
+      primaryPackageManager: "unknown",
+      packageManagers: ["unknown"],
+      monorepo: "none",
+    },
+    agents: [],
+    findings: [],
+    summary: { total: 0, critical: 0, warning: 0, info: 0 },
+    scores: null,
+    scoringAvailable: false,
+    agentSecurityAnalysis: "full",
+    timing: { discoveryMs: 0, detectionMs: 0, agentsMs: 0, rulesMs: 0, totalMs: 0 },
+  };
+}
+
+function baseResult(
+  overrides: Partial<VerifyResult> & { summary: VerifyResult["summary"] },
+): VerifyResult {
+  return {
+    version: "0.0.0-test",
+    repositoryRoot: "/tmp",
+    baselinePath: "/tmp/agentdoctor-report.json",
+    fixed: [],
+    remaining: [],
+    new: [],
+    unchanged: [],
+    after: emptyScan(),
+    scores: { overall: 100, byCategory: {}, byAgent: {} },
+    scoringAvailable: true,
+    timing: { scanMs: 1, compareMs: 1, totalMs: 2 },
+    ...overrides,
+  };
+}
+
+describe("verify Next steps", () => {
+  it("when findings remain, points at fix / explain / re-verify", () => {
+    const result = baseResult({
+      summary: { fixed: 1, remaining: 2, new: 0, unchanged: 1, before: 3, after: 2 },
+      remaining: [
+        {
+          id: "a",
+          ruleId: "security/env-file-exposure",
+          title: "env",
+          message: "m",
+          severity: "critical",
+          evidence: { path: ".env" },
+        },
+      ],
+    });
+
+    const next = renderVerifyNextSteps(result).join("\n");
+    expect(next).toContain("Next");
+    expect(next).toContain("still open");
+    expect(next).toContain("agentdoctor fix --dry-run");
+    expect(next).toContain("agentdoctor explain <rule-id>");
+    expect(next).toContain("agentdoctor verify --baseline agentdoctor-report.json");
+  });
+
+  it("when clean vs baseline, points at optional CI gate", () => {
+    const result = baseResult({
+      summary: { fixed: 2, remaining: 0, new: 0, unchanged: 0, before: 2, after: 0 },
+    });
+
+    const output = renderVerifyTerminalReport(result);
+    expect(output).toContain("Next");
+    expect(output).toContain("All tracked findings cleared");
+    expect(output).toContain("agentdoctor scan --ci");
+  });
+
+  it("when new findings appear, points at scan", () => {
+    const result = baseResult({
+      summary: { fixed: 0, remaining: 0, new: 1, unchanged: 0, before: 0, after: 1 },
+      new: [
+        {
+          id: "n",
+          ruleId: "context/generated-directory",
+          title: "dist",
+          message: "m",
+          severity: "info",
+          evidence: { path: "dist" },
+        },
+      ],
+    });
+
+    const next = renderVerifyNextSteps(result).join("\n");
+    expect(next).toContain("new finding(s) appeared");
+    expect(next).toContain("agentdoctor scan");
+  });
+});


### PR DESCRIPTION
## Summary
- Completes the first-user workflow: Claude/Codex safe-context Fix writers, shared CI policy gates, GitHub summary/annotations, and terminal + Step Summary **Next** guidance so a failed Action leads back to local fix/verify.
- Marks the Scan → Fix → Verify → CI loop complete/frozen in the roadmap unless users report friction.
- Leaves Understanding / validation lab work untracked and out of this PR.

## Test plan
- [x] `vitest` reporters / policy / path-resolution / fix-plan / hardening / CLI integration (76 tests)
- [ ] CI green on this PR
- [ ] Smoke: Action with `summary: true` fails a gate and shows **Next** in the job summary


Made with [Cursor](https://cursor.com)