### PR TITLE
fix: nested instruction-dir resolution for missing-path (#30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,10 @@ jobs:
           name: dist
           path: dist
 
+      - name: Install runtime dependencies for workspace CLI
+        if: matrix.version == 'workspace'
+        run: npm ci --omit=dev
+
       - name: Prepare output-path case
         env:
           CASE: ${{ matrix.case }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `instructions/missing-path-reference` also resolves non-`./` paths relative to the
+  instruction file directory (monorepo package docs), while root-level instruction
+  files still require repository-root paths. Corpus-100: 121 → 88 findings for this
+  rule (−33); other rules unchanged.
 - `context/generated-directory` and `context/large-log-file` honor Claude Code Read
   deny exclusions when computing `affectedAgents`, so Fix → Verify clears Claude
   context findings after a deny rule is applied.

--- a/README.md
+++ b/README.md
@@ -354,14 +354,14 @@ and deferred v2 items): [docs/scoring.md](docs/scoring.md).
 
 Honest limits of the current public beta:
 
-| Limitation                 | Status                                                              |
-| -------------------------- | ------------------------------------------------------------------- |
+| Limitation                 | Status                                                                                                                   |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | Automatic fixes            | Safe Cursor / Claude Code / Codex context exclusions (Unreleased; published `0.3.0-beta` is Cursor `.cursorignore` only) |
-| Security findings          | Review/manual — Fix does not rewrite secrets or security modes      |
-| GitHub Action policy gates | Unreleased Action inputs + CLI flags; published `@v0.3.0-beta` is report-only |
-| Secret-content scanning    | Filename / config heuristics only                                   |
-| Detection style            | Intentionally conservative; false security findings are avoided     |
-| Agent coverage             | Cursor, Claude Code, Codex project configs                          |
+| Security findings          | Review/manual — Fix does not rewrite secrets or security modes                                                           |
+| GitHub Action policy gates | Unreleased Action inputs + CLI flags; published `@v0.3.0-beta` is report-only                                            |
+| Secret-content scanning    | Filename / config heuristics only                                                                                        |
+| Detection style            | Intentionally conservative; false security findings are avoided                                                          |
+| Agent coverage             | Cursor, Claude Code, Codex project configs                                                                               |
 
 See [CHANGELOG.md](CHANGELOG.md) and [docs/compatibility.md](docs/compatibility.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,8 @@ First-user workflow is feature-complete and frozen unless real users report fric
 
 Engineering priority after this milestone: user-reported bugs, corpus-driven precision, performance regressions, and adoption feedback — not more workflow chrome.
 
+**Precision policy:** Prefer small, measurable precision improvements over large architectural rewrites. Ship the largest *safe* corpus-backed slice; leave harder residual noise until new evidence appears.
+
 ## Near term
 
 ### Scoring follow-ups (v2+)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ First-user workflow is feature-complete and frozen unless real users report fric
 
 Engineering priority after this milestone: user-reported bugs, corpus-driven precision, performance regressions, and adoption feedback — not more workflow chrome.
 
-**Precision policy:** Prefer small, measurable precision improvements over large architectural rewrites. Ship the largest *safe* corpus-backed slice; leave harder residual noise until new evidence appears.
+**Precision policy:** Prefer small, measurable precision improvements over large architectural rewrites. Ship the largest _safe_ corpus-backed slice; leave harder residual noise until new evidence appears.
 
 ## Near term
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,40 +4,40 @@ This document describes what consumers can rely on during the public beta.
 
 ## Stable in v0.3.x
 
-| Surface          | Promise                                                                                                                                                             |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| npm package name | `@praneeth_54/agentdoctor`                                                                                                                                          |
-| CLI binary name  | `agentdoctor`                                                                                                                                                       |
-| Default command  | Scan current directory / path argument                                                                                                                              |
-| Flags (published `0.3.0-beta`) | `--json`, `--ci` (report-only on scan), `--verbose`, `--min-score`, `--version`, `--help`                                                               |
-| Flags (Unreleased tree) | Above, plus `--fail-on-severity`, `--fail-on-rule`, `--fail-on-new` (verify), `--summary`, `--annotations`; `scan --ci` fails on criticals                    |
-| Commands         | `scan`, `fix`, `verify`, `explain <rule>`, `doctor`                                                                                                                 |
-| Exit codes       | `0` success, `1` policy / threshold / CI regression, `2` usage, `3` internal (see [exit-codes.md](exit-codes.md))                                                   |
-| Rule IDs         | `category/name` strings documented in [rules.md](rules.md)                                                                                                          |
-| Programmatic API | `scan()`, `verify()`, `buildFixPlan()`, `applyFixPlan()`, and `PACKAGE_VERSION` from package root export                                                            |
-| JSON top-level   | `version`, `repository`, `agents`, `findings`, `summary`, `scores`, `scoringAvailable`, `agentSecurityAnalysis`, `timing`, `diagnostics`                            |
+| Surface                        | Promise                                                                                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| npm package name               | `@praneeth_54/agentdoctor`                                                                                                                 |
+| CLI binary name                | `agentdoctor`                                                                                                                              |
+| Default command                | Scan current directory / path argument                                                                                                     |
+| Flags (published `0.3.0-beta`) | `--json`, `--ci` (report-only on scan), `--verbose`, `--min-score`, `--version`, `--help`                                                  |
+| Flags (Unreleased tree)        | Above, plus `--fail-on-severity`, `--fail-on-rule`, `--fail-on-new` (verify), `--summary`, `--annotations`; `scan --ci` fails on criticals |
+| Commands                       | `scan`, `fix`, `verify`, `explain <rule>`, `doctor`                                                                                        |
+| Exit codes                     | `0` success, `1` policy / threshold / CI regression, `2` usage, `3` internal (see [exit-codes.md](exit-codes.md))                          |
+| Rule IDs                       | `category/name` strings documented in [rules.md](rules.md)                                                                                 |
+| Programmatic API               | `scan()`, `verify()`, `buildFixPlan()`, `applyFixPlan()`, and `PACKAGE_VERSION` from package root export                                   |
+| JSON top-level                 | `version`, `repository`, `agents`, `findings`, `summary`, `scores`, `scoringAvailable`, `agentSecurityAnalysis`, `timing`, `diagnostics`   |
 
 ## Scoring (v1 shipped)
 
-| Surface              | Notes                                                                                             |
-| -------------------- | ------------------------------------------------------------------------------------------------- |
-| `scoringAvailable`   | `true`                                                                                            |
-| `scores`             | Populated `{ overall, categories, agents }` integers in `[0, 100]` (see [scoring.md](scoring.md)) |
-| Terminal summary     | Prints overall readiness (`N/100`); category/agent breakdown via `--json`                         |
-| `--min-score N`      | Enforced: exit `1` when `scores.overall < N` (`N` in `0`–`100`); Unreleased also fails when analysis is `limited` |
-| `--fail-on-severity` | Unreleased: exit `1` when any finding is at/above the given severity                                |
-| `--fail-on-rule`     | Unreleased: exit `1` when any finding matches a listed rule id                                      |
+| Surface              | Notes                                                                                                                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `scoringAvailable`   | `true`                                                                                                                     |
+| `scores`             | Populated `{ overall, categories, agents }` integers in `[0, 100]` (see [scoring.md](scoring.md))                          |
+| Terminal summary     | Prints overall readiness (`N/100`); category/agent breakdown via `--json`                                                  |
+| `--min-score N`      | Enforced: exit `1` when `scores.overall < N` (`N` in `0`–`100`); Unreleased also fails when analysis is `limited`          |
+| `--fail-on-severity` | Unreleased: exit `1` when any finding is at/above the given severity                                                       |
+| `--fail-on-rule`     | Unreleased: exit `1` when any finding matches a listed rule id                                                             |
 | `--ci` (scan)        | Published `0.3.0-beta`: report-only. Unreleased: exit `1` on any **critical** finding (override with `--fail-on-severity`) |
-| Algorithm stability  | Weights / caps are frozen in [scoring.md](scoring.md); retunes require an explicit doc revision   |
+| Algorithm stability  | Weights / caps are frozen in [scoring.md](scoring.md); retunes require an explicit doc revision                            |
 
 ## Fix + Verify
 
-| Surface                         | Notes                                                                                                                                                          |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Surface                         | Notes                                                                                                                                                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `fix`                           | Published `0.3.0-beta`: safe Cursor `.cursorignore` only. Unreleased: also Claude Code `permissions.deny` Read and Codex filesystem deny for context findings; review/manual skipped |
-| `verify`                        | Compares a re-scan to a prior `scan --json` baseline (`fixed` / `remaining` / `new`)                                                                           |
-| `verify --ci` / `--fail-on-new` | Exit `1` when **new** findings appear relative to the baseline (`--fail-on-new` Unreleased)                                                                   |
-| Finding `id` values             | Stable for compare when evidence paths are unchanged; may change if evidence keys change                                                                       |
+| `verify`                        | Compares a re-scan to a prior `scan --json` baseline (`fixed` / `remaining` / `new`)                                                                                                 |
+| `verify --ci` / `--fail-on-new` | Exit `1` when **new** findings appear relative to the baseline (`--fail-on-new` Unreleased)                                                                                          |
+| Finding `id` values             | Stable for compare when evidence paths are unchanged; may change if evidence keys change                                                                                             |
 
 ## Explicitly unstable / reserved
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -30,17 +30,17 @@ revision explicitly supersedes it.
 
 ## Shipped v1 behavior
 
-| Surface                      | Behavior                                                                                         |
-| ---------------------------- | ------------------------------------------------------------------------------------------------ |
-| `scoringAvailable`           | `true`                                                                                           |
-| `scores`                     | Populated `{ overall, categories, agents }`                                                      |
-| `--min-score N`              | Exit `1` if `scores.overall < N`, or if analysis is `limited` (no supported agents)              |
-| `--ci` (this repository)     | Exit `1` on any **critical** finding (override with `--fail-on-severity`)                        |
-| `--ci` (published `0.3.0-beta`) | Report-only; exit `0` on successful scan unless `--min-score` fails                           |
-| Successful scan with findings | Exit code `0` unless a policy / threshold gate fails                                            |
-| Exit code `1`                | Policy / threshold / CI gate failure                                                             |
-| Terminal                     | Prints overall readiness (`N/100`, or `n/a` when analysis is limited); category/agent via JSON   |
-| GitHub Action                | Published `@v0.3.0-beta` report-only; Unreleased Action adds policy inputs (see README / CHANGELOG) |
+| Surface                         | Behavior                                                                                            |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `scoringAvailable`              | `true`                                                                                              |
+| `scores`                        | Populated `{ overall, categories, agents }`                                                         |
+| `--min-score N`                 | Exit `1` if `scores.overall < N`, or if analysis is `limited` (no supported agents)                 |
+| `--ci` (this repository)        | Exit `1` on any **critical** finding (override with `--fail-on-severity`)                           |
+| `--ci` (published `0.3.0-beta`) | Report-only; exit `0` on successful scan unless `--min-score` fails                                 |
+| Successful scan with findings   | Exit code `0` unless a policy / threshold gate fails                                                |
+| Exit code `1`                   | Policy / threshold / CI gate failure                                                                |
+| Terminal                        | Prints overall readiness (`N/100`, or `n/a` when analysis is limited); category/agent via JSON      |
+| GitHub Action                   | Published `@v0.3.0-beta` report-only; Unreleased Action adds policy inputs (see README / CHANGELOG) |
 
 Production scoring uses `computeReadinessScores` (pure function of post-dedupe findings).
 An internal `filesScanned`-based placeholder exists for historical unit tests only and

--- a/src/core/fix/render.ts
+++ b/src/core/fix/render.ts
@@ -29,15 +29,9 @@ export function renderFixPlanTerminal(
       }
       lines.push("");
       lines.push("Next");
-      lines.push(
-        "  Inspect a finding: agentdoctor explain <rule-id>  (ids in scan --json)",
-      );
-      lines.push(
-        "  Confirm with verify: agentdoctor verify --baseline agentdoctor-report.json",
-      );
-      lines.push(
-        "  No baseline yet? agentdoctor scan --json > agentdoctor-report.json",
-      );
+      lines.push("  Inspect a finding: agentdoctor explain <rule-id>  (ids in scan --json)");
+      lines.push("  Confirm with verify: agentdoctor verify --baseline agentdoctor-report.json");
+      lines.push("  No baseline yet? agentdoctor scan --json > agentdoctor-report.json");
     } else {
       lines.push("  Scan found nothing that Fix can change.");
       lines.push("");
@@ -130,16 +124,10 @@ export function renderFixPlanTerminal(
     lines.push("  Apply these changes: agentdoctor fix -y");
   }
   if (plan.skipped.length > 0) {
-    lines.push(
-      "  Review/manual findings stay open — inspect with: agentdoctor explain <rule-id>",
-    );
+    lines.push("  Review/manual findings stay open — inspect with: agentdoctor explain <rule-id>");
   }
-  lines.push(
-    "  Confirm with verify: agentdoctor verify --baseline agentdoctor-report.json",
-  );
-  lines.push(
-    "  No baseline yet? agentdoctor scan --json > agentdoctor-report.json",
-  );
+  lines.push("  Confirm with verify: agentdoctor verify --baseline agentdoctor-report.json");
+  lines.push("  No baseline yet? agentdoctor scan --json > agentdoctor-report.json");
   lines.push("");
   return lines.join("\n");
 }

--- a/src/core/path-resolution/prepare.ts
+++ b/src/core/path-resolution/prepare.ts
@@ -10,13 +10,7 @@
  */
 
 export type PathConcreteRejectReason =
-  | "empty"
-  | "placeholder"
-  | "ellipsis"
-  | "home"
-  | "git-ref"
-  | "bundler-module-type"
-  | "undecodable";
+  "empty" | "placeholder" | "ellipsis" | "home" | "git-ref" | "bundler-module-type" | "undecodable";
 
 export type PreparedPathReference =
   | {
@@ -63,7 +57,8 @@ function looksLikeGitRef(normalized: string): boolean {
  * Bundler module-type tokens (`asset/resource`, `javascript/auto`) — not paths.
  * Generalized type/name pattern; no bundler product names.
  */
-const BUNDLER_MODULE_TYPE = /^(?:asset|javascript|css|json|wasm|webassembly|runtime)\/[A-Za-z0-9_-]+$/;
+const BUNDLER_MODULE_TYPE =
+  /^(?:asset|javascript|css|json|wasm|webassembly|runtime)\/[A-Za-z0-9_-]+$/;
 
 /**
  * Normalize a path reference for filesystem checks:

--- a/src/core/rules/context/generated-directory.ts
+++ b/src/core/rules/context/generated-directory.ts
@@ -8,7 +8,6 @@ import {
 } from "../path-kind.js";
 import type { FindingDraft, RuleContext, RuleDefinition } from "../types.js";
 
-
 /** Directories commonly generated/build-related. vendor/ is ecosystem-aware. */
 const GENERATED = [
   { name: "dist", label: "build output" },

--- a/src/core/rules/instructions/missing-path-reference.ts
+++ b/src/core/rules/instructions/missing-path-reference.ts
@@ -186,7 +186,11 @@ function isEscapingRepoRelative(relativePath: string): boolean {
 /**
  * Resolve a candidate path reference with repository-aware semantics:
  * - `./` and `../` → relative to the instruction file directory
- * - otherwise → repository-root relative (avoids nesting under `.cursor/rules/`)
+ * - otherwise → repository-root relative, plus the same path under the
+ *   instruction file directory when nested (monorepo package docs)
+ *
+ * Does not search sibling packages: a root `AGENTS.md` reference must still
+ * exist at the repository root (or via `./` / `../`).
  */
 export function resolveInstructionPathReference(
   instructionRelativePath: string,
@@ -216,9 +220,24 @@ export function resolveInstructionPathReference(
     return { status: "escape", attempted: rootRelative };
   }
 
+  const pathsToCheck = [rootRelative];
+
+  if (instructionDir !== ".") {
+    const fromInstruction = path.posix.normalize(
+      path.posix.join(instructionDir, rootRelative),
+    );
+    if (
+      !isEscapingRepoRelative(fromInstruction) &&
+      !fromInstruction.startsWith("/") &&
+      fromInstruction !== rootRelative
+    ) {
+      pathsToCheck.push(fromInstruction);
+    }
+  }
+
   return {
     status: "ok",
-    pathsToCheck: [rootRelative],
+    pathsToCheck,
     primaryRelative: rootRelative,
   };
 }

--- a/src/core/rules/instructions/missing-path-reference.ts
+++ b/src/core/rules/instructions/missing-path-reference.ts
@@ -223,9 +223,7 @@ export function resolveInstructionPathReference(
   const pathsToCheck = [rootRelative];
 
   if (instructionDir !== ".") {
-    const fromInstruction = path.posix.normalize(
-      path.posix.join(instructionDir, rootRelative),
-    );
+    const fromInstruction = path.posix.normalize(path.posix.join(instructionDir, rootRelative));
     if (
       !isEscapingRepoRelative(fromInstruction) &&
       !fromInstruction.startsWith("/") &&
@@ -278,10 +276,7 @@ export const missingPathReferenceRule: RuleDefinition = {
             continue;
           }
 
-          const resolved = resolveInstructionPathReference(
-            file.relativePath,
-            prepared.normalized,
-          );
+          const resolved = resolveInstructionPathReference(file.relativePath, prepared.normalized);
 
           if (resolved.status === "escape") {
             findings.push({

--- a/src/core/rules/path-kind.ts
+++ b/src/core/rules/path-kind.ts
@@ -189,9 +189,6 @@ export function isCheckedInGithubActionDist(relativePath: string): boolean {
   if (!relativePath) {
     return false;
   }
-  const normalized = relativePath
-    .replace(/\\/g, "/")
-    .replace(/^\.\//, "")
-    .replace(/\/+$/, "");
+  const normalized = relativePath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "");
   return /^\.github\/actions\/[^/]+\/dist$/i.test(normalized);
 }

--- a/src/reporters/github/summary.ts
+++ b/src/reporters/github/summary.ts
@@ -92,8 +92,9 @@ function renderGithubNextSteps(input: GithubSummaryInput): string[] {
   lines.push("");
 
   const hasSafe = input.findings.some((f) => f.fixability === "safe");
-  const topRule = [...input.findings]
-    .sort((a, b) => severityOrder(b.severity) - severityOrder(a.severity))[0]?.ruleId;
+  const topRule = [...input.findings].sort(
+    (a, b) => severityOrder(b.severity) - severityOrder(a.severity),
+  )[0]?.ruleId;
 
   if (input.mode === "verify") {
     lines.push("1. Reproduce locally: `npx @praneeth_54/agentdoctor verify`");
@@ -120,9 +121,7 @@ function renderGithubNextSteps(input: GithubSummaryInput): string[] {
   }
 
   lines.push("");
-  lines.push(
-    "Preview before applying: `npx @praneeth_54/agentdoctor fix --dry-run`",
-  );
+  lines.push("Preview before applying: `npx @praneeth_54/agentdoctor fix --dry-run`");
   lines.push("");
   return lines;
 }

--- a/src/reporters/terminal/report.ts
+++ b/src/reporters/terminal/report.ts
@@ -128,13 +128,9 @@ export function renderNextSteps(result: ScanResult): string[] {
     );
   }
   lines.push(
-    colors.dim(
-      "  Save a verify baseline: agentdoctor scan --json > agentdoctor-report.json",
-    ),
+    colors.dim("  Save a verify baseline: agentdoctor scan --json > agentdoctor-report.json"),
   );
-  lines.push(
-    colors.dim("  After changes: agentdoctor verify --baseline agentdoctor-report.json"),
-  );
+  lines.push(colors.dim("  After changes: agentdoctor verify --baseline agentdoctor-report.json"));
   lines.push("");
   return lines;
 }
@@ -217,7 +213,9 @@ export function renderTerminalReport(
 
   if (total === 0) {
     if (limited) {
-      lines.push(`  ${symbolWarn()} Nothing to audit yet — no Cursor, Claude Code, or Codex config found`);
+      lines.push(
+        `  ${symbolWarn()} Nothing to audit yet — no Cursor, Claude Code, or Codex config found`,
+      );
       lines.push("");
       lines.push(
         colors.dim(
@@ -275,11 +273,7 @@ export function renderTerminalReport(
   lines.push(`  ${result.summary.info} info`);
   if (total > 0) {
     const { safe, review, manual } = countByFixability(result.findings);
-    lines.push(
-      colors.dim(
-        `  Fixability: ${safe} safe · ${review} review · ${manual} manual`,
-      ),
-    );
+    lines.push(colors.dim(`  Fixability: ${safe} safe · ${review} review · ${manual} manual`));
   }
   lines.push("");
   if (result.scoringAvailable && result.scores) {

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -255,13 +255,7 @@ describe("CLI program", () => {
   });
 
   it("argv: invalid --min-score is a usage error (not internal error)", async () => {
-    const { exitCode } = await parseCli([
-      "scan",
-      cleanProject,
-      "--json",
-      "--min-score",
-      "999",
-    ]);
+    const { exitCode } = await parseCli(["scan", cleanProject, "--json", "--min-score", "999"]);
     expect(exitCode).toBe(EXIT_CODES.USAGE_ERROR);
     expect(exitCode).not.toBe(EXIT_CODES.INTERNAL_ERROR);
   });

--- a/tests/unit/fix/fix-next-steps.test.ts
+++ b/tests/unit/fix/fix-next-steps.test.ts
@@ -6,13 +6,15 @@ import type { FixPlan } from "../../../src/core/fix/types.js";
 describe("fix Next steps workflow", () => {
   it("dry-run with actions points at fix -y then verify", () => {
     const plan: FixPlan = {
+      root: "/tmp",
       actions: [
         {
           id: "a1",
           agent: "cursor",
-          kind: "cursorignore-append",
+          kind: "append-ignore-pattern",
           description: "Ignore dist/",
           pattern: "dist/",
+          evidencePath: "dist",
           findingIds: ["f1"],
           targetRelativePath: ".cursorignore",
         },
@@ -40,6 +42,7 @@ describe("fix Next steps workflow", () => {
 
   it("review-only plan points at explain and verify, not fix -y", () => {
     const plan: FixPlan = {
+      root: "/tmp",
       actions: [],
       skipped: [
         {

--- a/tests/unit/rules/missing-path-reference.test.ts
+++ b/tests/unit/rules/missing-path-reference.test.ts
@@ -77,15 +77,42 @@ describe("isLikelyLocalPathReference", () => {
 });
 
 describe("resolveInstructionPathReference", () => {
-  it("resolves repo-root-style paths from repository root", () => {
+  it("resolves repo-root-style paths from repository root and nested instruction dir", () => {
     const result = resolveInstructionPathReference(
       ".cursor/rules/example.mdc",
       "project/backend/includes/config.php",
     );
     expect(result).toEqual({
       status: "ok",
-      pathsToCheck: ["project/backend/includes/config.php"],
+      pathsToCheck: [
+        "project/backend/includes/config.php",
+        ".cursor/rules/project/backend/includes/config.php",
+      ],
       primaryRelative: "project/backend/includes/config.php",
+    });
+  });
+
+  it("resolves package-local shorthand from a nested instruction file", () => {
+    const result = resolveInstructionPathReference(
+      "compiler/CLAUDE.md",
+      "packages/babel-plugin-react-compiler/",
+    );
+    expect(result).toEqual({
+      status: "ok",
+      pathsToCheck: [
+        "packages/babel-plugin-react-compiler/",
+        "compiler/packages/babel-plugin-react-compiler/",
+      ],
+      primaryRelative: "packages/babel-plugin-react-compiler/",
+    });
+  });
+
+  it("keeps root instruction paths root-only", () => {
+    const result = resolveInstructionPathReference("AGENTS.md", "src/");
+    expect(result).toEqual({
+      status: "ok",
+      pathsToCheck: ["src/"],
+      primaryRelative: "src/",
     });
   });
 
@@ -271,5 +298,31 @@ describe("instructions/missing-path-reference regressions", () => {
 
     const findings = missingPathFindings(await scan({ cwd: root }));
     expect(findings).toHaveLength(0);
+  });
+
+  it("does not flag package-local paths that exist beside a nested instruction file", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.mkdir(path.join(root, "packages/auth-js/src"), { recursive: true });
+    await fs.writeFile(path.join(root, "packages/auth-js/package.json"), "{}\n");
+    await fs.writeFile(path.join(root, "packages/auth-js/src/index.ts"), "export {};\n");
+    await fs.writeFile(
+      path.join(root, "packages/auth-js/AGENTS.md"),
+      "Implement features under `src/` and ship `migrations/`.\n",
+    );
+    await fs.mkdir(path.join(root, "packages/auth-js/migrations"), { recursive: true });
+
+    const findings = missingPathFindings(await scan({ cwd: root }));
+    expect(findings).toHaveLength(0);
+  });
+
+  it("still flags root AGENTS.md refs that only exist under a sibling package", async () => {
+    const root = await tempRepo();
+    await fs.writeFile(path.join(root, "package.json"), "{}\n");
+    await fs.mkdir(path.join(root, "packages/auth-js/migrations"), { recursive: true });
+    await fs.writeFile(path.join(root, "AGENTS.md"), "See `migrations/` for SQL.\n");
+
+    const findings = missingPathFindings(await scan({ cwd: root }));
+    expect(findings.some((f) => f.evidence?.detail === "missing=migrations/")).toBe(true);
   });
 });

--- a/tests/unit/rules/path-kind.test.ts
+++ b/tests/unit/rules/path-kind.test.ts
@@ -196,7 +196,10 @@ describe("sample/test path suppression across security rules", () => {
       "-----BEGIN PRIVATE KEY-----\nU\n",
     );
     await fs.mkdir(path.join(root, "smoke-test/ssl"), { recursive: true });
-    await fs.writeFile(path.join(root, "smoke-test/ssl/ssl.key"), "-----BEGIN PRIVATE KEY-----\nS\n");
+    await fs.writeFile(
+      path.join(root, "smoke-test/ssl/ssl.key"),
+      "-----BEGIN PRIVATE KEY-----\nS\n",
+    );
 
     const result = await scan({ cwd: root });
     const keys = result.findings.filter((f) => f.ruleId === "security/private-key-file");

--- a/tests/unit/verify/verify-next-steps.test.ts
+++ b/tests/unit/verify/verify-next-steps.test.ts
@@ -27,7 +27,15 @@ function emptyScan(): ScanResult {
     scores: null,
     scoringAvailable: false,
     agentSecurityAnalysis: "full",
-    timing: { discoveryMs: 0, detectionMs: 0, agentsMs: 0, rulesMs: 0, totalMs: 0 },
+    timing: {
+      discoveryMs: 0,
+      detectionMs: 0,
+      agentsMs: 0,
+      rulesMs: 0,
+      scoringMs: 0,
+      totalMs: 0,
+    },
+    diagnostics: { warnings: [], errors: [] },
   };
 }
 
@@ -43,7 +51,18 @@ function baseResult(
     new: [],
     unchanged: [],
     after: emptyScan(),
-    scores: { overall: 100, byCategory: {}, byAgent: {} },
+    scores: {
+      overall: 100,
+      categories: {
+        security: 100,
+        context: 100,
+        instructions: 100,
+        mcp: 100,
+        compatibility: 100,
+        performance: 100,
+      },
+      agents: { cursor: 100, "claude-code": 100, codex: 100 },
+    },
     scoringAvailable: true,
     timing: { scanMs: 1, compareMs: 1, totalMs: 2 },
     ...overrides,


### PR DESCRIPTION
## Summary
- Resolves non-`./` path references relative to the instruction file directory as well as the repo root (monorepo package docs).
- No cross-package / sibling-package guessing — root `AGENTS.md` refs still require a repository-root path.
- Records the precision policy: prefer small measurable corpus-backed slices over lattice rewrites.
- Partial progress on #30 (left open). #29 already closed.

## Corpus-100 gate (same local checkouts)
| Metric | Before | After | Δ |
| --- | ---: | ---: | ---: |
| Total findings | 190 | 157 | −33 |
| `instructions/missing-path-reference` | 121 | 88 | −33 |
| `security/private-key-file` | 4 | 4 | 0 |
| Other rules | — | unchanged | 0 |

Merge only if remeasure matches **mp=88, total=157, pk=4**.

## Test plan
- [x] `vitest` missing-path-reference (24)
- [x] Corpus-100 A/B on PR commit
- [ ] CI unit/integration green


Made with [Cursor](https://cursor.com)